### PR TITLE
Harden JMeter benchmark execution, load profiles, reporting, and validation

### DIFF
--- a/.github/workflows/jmeter-checks.yml
+++ b/.github/workflows/jmeter-checks.yml
@@ -1,0 +1,25 @@
+name: JMeter framework checks
+
+on:
+  pull_request:
+    paths:
+      - "jmeter_benchmarks/**"
+      - ".github/workflows/jmeter-checks.yml"
+  push:
+    paths:
+      - "jmeter_benchmarks/**"
+      - ".github/workflows/jmeter-checks.yml"
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: jmeter_benchmarks/jmeter-jdbc-test-framework
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run pre-merge checks
+        run: ./utilities/run_premerge_checks.sh

--- a/README.md
+++ b/README.md
@@ -1,16 +1,75 @@
-# e6data Benchmarking Utilities
-This repo is a collection of tools built by the e6data team for benchmarking & comparing analytical engine performance.
+# e6data Public Benchmarks
 
->These tools were built for internal use and may not have gone through stringent compatibility tests or security checks. Recommended only for use in non-production/lab environments.
+This repository contains three independent toolsets for running and comparing analytical-engine benchmarks. Use it in a lab or other non-production environment: the runners can generate substantial load, and the utilities have not been hardened as production services.
 
-## Tools
+## Choose a tool
 
-- [JMeter JDBC Test Framework](jmeter_benchmarks/jmeter-jdbc-test-framework/)
-  - JMeter-based JDBC performance testing framework for load and concurrency testing
-  - Property-file-driven architecture for reusable, automation-friendly test execution
-  - Supports multiple database engines (E6Data, Databricks, Trino, etc.)
-  - Includes batch testing with concurrency sweeps, S3 result storage, Athena integration, and comparison utilities
-- [Benchmarking POV Tool](pov/)
-  - Django-based GUI for running benchmarks
-- [Python scripts for various engines](python_benchmarks/)
-  - Python-based benchmark scripts for various analytical engines
+| Tool | Best for | Engines / interfaces | Start here |
+|---|---|---|---|
+| JMeter JDBC Test Framework | Repeatable concurrency, QPS/QPM, load-profile, and regression tests | JDBC and HTTP endpoints; connection templates cover e6data, Databricks, Trino, and others | [JMeter guide](jmeter_benchmarks/jmeter-jdbc-test-framework/README.md) |
+| Python benchmarks | Small sequential or batched-concurrency runs from a query CSV | e6data, Trino, and Amazon Athena | [Python guide](python_benchmarks/README.md) |
+| Benchmark POV Tool | Browser-based e6data-versus-Databricks comparisons | Docker Compose deployment of prebuilt UI, API, and MySQL images | [POV guide](pov/README.md) |
+
+The toolsets do not share a common runtime or configuration. Enter the selected tool's directory and follow its README.
+
+## JMeter quick start
+
+The JMeter framework is the recommended entry point for repeatable query-engine load tests. After cloning the repository:
+
+```bash
+cd jmeter_benchmarks/jmeter-jdbc-test-framework
+./setup_jmeter.sh
+./create_connection.sh
+mkdir -p data_files
+cp /path/to/my_queries.csv data_files/my_queries.csv
+cp test_configs/sample_benchmark.env test_configs/my_benchmark.env
+```
+
+Edit only `CONNECTION_FILE` and `QUERY_FILE` in `my_benchmark.env`, then choose a load model with command-line overrides:
+
+```bash
+# Fixed concurrency
+CONCURRENT_QUERY_COUNT=4 HOLD_PERIOD=300 \
+  ./run_test.sh test_configs/my_benchmark.env
+
+# Constant arrival rate
+TEST_PLAN=Test-Plans/Test-Plan-Constant-QPS-On-Arrivals-JSR-Optimized.jmx \
+  QPS=5 HOLD_PERIOD=300 ./run_test.sh test_configs/my_benchmark.env
+
+# Variable arrival rate from CSV
+TEST_PLAN=Test-Plans/Test-Plan-Fire-QPS-with-load-profile.jmx \
+  LOAD_PROFILE=test_properties/load_profile.csv \
+  ./run_test.sh test_configs/my_benchmark.env
+
+# Variable concurrency from CSV
+TEST_PLAN=Test-Plans/Test-Plan-Maintain-variable-concurrency-with-load-profile.jmx \
+  LOAD_PROFILE=test_properties/utg_load_profile.csv \
+  ./run_test.sh test_configs/my_benchmark.env
+```
+
+See the [complete JMeter guide](jmeter_benchmarks/jmeter-jdbc-test-framework/README.md) for run-once, QPM, HTTP, custom profiles, reports, S3/Athena analysis, and metric definitions.
+
+## Repository layout
+
+```text
+.
+├── jmeter_benchmarks/jmeter-jdbc-test-framework/
+│   ├── Test-Plans/          # JDBC and HTTP JMeter plans
+│   ├── test_properties/     # runtime and load-profile examples
+│   ├── test_configs/        # runner configuration examples
+│   ├── utilities/           # local, S3, and Athena analysis tools
+│   └── run_test.sh          # non-interactive runner
+├── python_benchmarks/       # one Python runner per supported engine
+└── pov/                     # Docker Compose deployment wrapper
+```
+
+## Safety and credentials
+
+- Start with a small workload and monitor the target engine before increasing concurrency or arrival rate.
+- Keep access tokens, JDBC credentials, AWS credentials, query data, and generated reports out of version control. The repository ignores the common local files, but verify `git status` before committing.
+- The POV Compose file ships demonstration credentials in `pov/.env`; replace them before exposing it beyond localhost.
+- Benchmark like-for-like datasets and cluster sizes, and distinguish client-observed latency from engine execution time when comparing results.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/.gitignore
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/.gitignore
@@ -49,6 +49,13 @@ test_configs/*.txt
 
 # Test properties CSV files (environment-specific data)
 test_properties/*.csv
+# ...except the load-profile examples. The two profile-driven plans fall back to
+# load_profile.csv / utg_load_profile.csv when LOAD_PROFILE is unset, so without
+# these a fresh clone cannot run either plan. They hold only shape numbers.
+!test_properties/load_profile.csv
+!test_properties/utg_load_profile.csv
+!test_properties/load_profile_5min.csv
+!test_properties/utg_load_profile_5min.csv
 
 # JDBC driver JARs
 jdbc_drivers/*.jar

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/CLAUDE.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/CLAUDE.md
@@ -397,9 +397,15 @@ RECYCLE_ON_EOF=false
 
 **IMPORTANT:** The test **ALWAYS runs for the full HOLD_PERIOD duration**, regardless of RECYCLE_ON_EOF setting or when queries finish.
 
-**HOLD_PERIOD is in SECONDS** (despite misleading comments in properties files saying "minutes"):
+**HOLD_PERIOD is in SECONDS** on every plan except one:
 - `HOLD_PERIOD=300` = 5 minutes (not 5 hours!)
 - Test duration = `RAMP_UP_TIME` + `HOLD_PERIOD` (in seconds)
+- **Exception:** `Test-Plan-Constant-QPM-On-Arrivals.jmx` runs on `Unit=M`, which
+  governs both the rate denominator and the hold duration, so there `HOLD_PERIOD`
+  is in **MINUTES** — `HOLD_PERIOD=5` means 5 minutes. This cannot be normalized
+  without breaking the queries-per-minute rate; the runners print a warning.
+- Not used at all by `Run-Once` (bounded by query count) or the two load-profile
+  plans (bounded by the profile).
 
 **When `RECYCLE_ON_EOF=false` (run queries once):**
 - Queries from CSV are read once
@@ -428,16 +434,29 @@ JDBC drivers are stored in `jdbc_drivers/` directory:
 
 The `setup_jmeter.sh` script handles this automatically.
 
-## Load Profile Tests (variable QPS)
+## Load Profile Tests
 
-`Test-Plan-Fire-QPS-with-load-profile.jmx` fires queries at a rate that varies over time,
-driven by a CSV. Point `LOAD_PROFILE` at any CSV — no per-profile test plan is needed:
+Two plans vary their load over time from a CSV. They control **different things**, so they
+take **different CSV formats** — the format is chosen from the plan, not from a flag.
+
+| Plan | Thread group | Controls | CSV |
+|---|---|---|---|
+| `Test-Plan-Fire-QPS-with-load-profile.jmx` | `FreeFormArrivalsThreadGroup` | arrival rate | 3 columns |
+| `Test-Plan-Maintain-variable-concurrency-with-load-profile.jmx` | `UltimateThreadGroup` | concurrency | 5 columns |
+
+Point `LOAD_PROFILE` at any CSV — no per-profile test plan is needed:
 
 ```bash
 LOAD_PROFILE=test_properties/my_profile.csv ./run_jmeter_tests_interactive.sh
 ```
 
-CSV format (header optional), duration in seconds:
+If `LOAD_PROFILE` is unset, the default follows the plan: `test_properties/load_profile.csv`
+for the QPS plan, `test_properties/utg_load_profile.csv` for the concurrency plan.
+
+### Arrival-rate CSV (3 columns)
+
+Controls how fast queries are *submitted*, regardless of whether earlier ones finished.
+Durations in seconds; header optional.
 
 ```
 StartValue,EndValue,Duration
@@ -446,22 +465,50 @@ StartValue,EndValue,Duration
 1,10,5       # ramp 1 -> 10 QPS over 5s
 ```
 
-Required settings for this plan type:
-
 | Setting | Why |
 |---|---|
 | `RECYCLE_ON_EOF=true` | without it threads hit EOF and vanish before the profile finishes |
 | `MAX_CONCURRANCY` | must exceed `peak_qps x latency_seconds`, or arrivals are silently dropped |
 | `HOLD_PERIOD` | at least the profile's total duration, plus time for the backlog to drain |
 
+### Concurrency CSV (5 columns)
+
+Controls how many queries run *at once*. Rows **stack** — each adds its threads on top of
+any wave still running — and ramp linearly over `StartupTime` / `ShutdownTime`.
+
+```
+Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+10,0,30,60,10     # ramp to 10 over 30s, hold 60s, wind down over 10s
+20,90,30,60,10    # +20 more from t=90  -> 30 concurrent at the plateau
+```
+
+For a flat step with no ramp, set `StartupTime=0` and `ShutdownTime=0`:
+
+```
+Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+2,0,0,45,0
+3,45,0,45,0
+```
+
+`RECYCLE_ON_EOF=true` is needed here too. `MAX_CONCURRANCY` and `HOLD_PERIOD` are not used
+by this plan — the CSV alone sets both the concurrency and the run length.
+
+### Verifying it took effect
+
 Every run prints what was applied — its absence means the profile did not take effect:
 
 ```
-load profile applied: 15 steps, 17s, peak 56/s, ~482 expected samples
+load profile applied (arrival rate): 15 steps, 17s, peak 56/s, ~482 expected samples
+load profile applied (concurrency): 2 waves, 90s, peak 3 concurrent, levels [2, 3]
 ```
 
-Afterwards, `run_report.md` reports delivered-vs-expected arrivals. A `SHORTFALL` verdict
-means `MAX_CONCURRANCY` was too low. To inspect further:
+Afterwards `run_report.md` scores the run against the profile:
+
+- **arrival rate** — delivered vs expected arrivals. `SHORTFALL` means `MAX_CONCURRANCY`
+  was too low.
+- **concurrency** — how many seconds in-flight stayed within 1 of the profile. A brief
+  overshoot at a wave boundary is expected: a thread finishes its current query before
+  stopping, so the outgoing and incoming waves overlap for a few seconds.
 
 ```bash
 python3 utilities/verify_load_profile.py reports/<run_id>/JmeterResultFile.csv <profile>.csv
@@ -469,9 +516,37 @@ python3 utilities/analyze_queue_buildup.py reports/<run_id>/JmeterResultFile.csv
 ```
 
 **Implementation note:** the schedule is injected into a copy of the plan by
-`utilities/apply_load_profile.py` before JMeter starts. The plan also contains a JSR223
-PreProcessor that appears to do this, but cannot — a PreProcessor runs when a sampler
-fires, after the thread group has already read its schedule.
+`utilities/apply_load_profile.py` before JMeter starts — into `Schedule` for the arrivals
+plan, `ultimatethreadgroupdata` for the concurrency plan. Both plans also contain JSR223
+PreProcessors that appear to do this, but cannot — a PreProcessor runs when a sampler
+fires, after the thread group has already read its schedule and started threads. Those
+elements ship `enabled="false"`; leave them that way.
+
+## Exit Codes
+
+Both runners exit non-zero when a run did not produce a usable result. This matters
+because JMeter itself returns 0 even when every sample failed — a run against an
+unreachable cluster used to print "Test Complete!" and exit 0, so any script or CI
+wrapped around it reported success on numbers that meant nothing.
+
+| Code | Meaning |
+|---|---|
+| 0 | Run completed, error rate within `MAX_ERROR_PCT` |
+| 1 | Not a usable result — no samples recorded, or error rate above the threshold |
+
+`MAX_ERROR_PCT` defaults to **5**. The results directory is still written on failure
+so the run can be diagnosed, and the banner reads `Test FAILED` instead of
+`Test Complete!`. The report prints the top failure messages:
+
+```
+  run report: 25 samples, 100.0% errors, 2.18/s, peak 2 in flight
+  [FAIL] error rate 100.0% exceeds the 5.0% threshold - this run is not a usable result
+         25x java.sql.SQLException: UNIMPLEMENTED: No cluster-name header or unknown cluster
+```
+
+Set `MAX_ERROR_PCT=100` when errors are expected (fault-injection, capacity limits).
+`utilities/capture_run_report.py` uses exit code 2 for this so callers can tell a
+failed *run* from a failed *script*; the runners translate it to 1.
 
 ## Report Output
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/CLAUDE.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/CLAUDE.md
@@ -126,6 +126,11 @@ Interactive utility that creates connection properties files for JDBC (e6data, D
 ./run_jmeter_tests_interactive.sh
 ```
 
+Prompts accept a **filename as well as a list number**. Prefer filenames when scripting:
+the list is rebuilt from the directory each run and numbered by sort position, so adding a
+connection or properties file shifts every index after it and a piped number then selects a
+different file silently.
+
 This script:
 1. Lists existing connection properties files for selection (if none exist, directs to `create_connection.sh`)
 2. Prompts for test plan type (concurrency, QPS, QPM, load profile, variable concurrency; JDBC or HTTP variants)
@@ -423,20 +428,81 @@ JDBC drivers are stored in `jdbc_drivers/` directory:
 
 The `setup_jmeter.sh` script handles this automatically.
 
+## Load Profile Tests (variable QPS)
+
+`Test-Plan-Fire-QPS-with-load-profile.jmx` fires queries at a rate that varies over time,
+driven by a CSV. Point `LOAD_PROFILE` at any CSV — no per-profile test plan is needed:
+
+```bash
+LOAD_PROFILE=test_properties/my_profile.csv ./run_jmeter_tests_interactive.sh
+```
+
+CSV format (header optional), duration in seconds:
+
+```
+StartValue,EndValue,Duration
+3,3,1        # 3 QPS for 1s
+5,5,2        # 5 QPS for 2s
+1,10,5       # ramp 1 -> 10 QPS over 5s
+```
+
+Required settings for this plan type:
+
+| Setting | Why |
+|---|---|
+| `RECYCLE_ON_EOF=true` | without it threads hit EOF and vanish before the profile finishes |
+| `MAX_CONCURRANCY` | must exceed `peak_qps x latency_seconds`, or arrivals are silently dropped |
+| `HOLD_PERIOD` | at least the profile's total duration, plus time for the backlog to drain |
+
+Every run prints what was applied — its absence means the profile did not take effect:
+
+```
+load profile applied: 15 steps, 17s, peak 56/s, ~482 expected samples
+```
+
+Afterwards, `run_report.md` reports delivered-vs-expected arrivals. A `SHORTFALL` verdict
+means `MAX_CONCURRANCY` was too low. To inspect further:
+
+```bash
+python3 utilities/verify_load_profile.py reports/<run_id>/JmeterResultFile.csv <profile>.csv
+python3 utilities/analyze_queue_buildup.py reports/<run_id>/JmeterResultFile.csv --bucket 5
+```
+
+**Implementation note:** the schedule is injected into a copy of the plan by
+`utilities/apply_load_profile.py` before JMeter starts. The plan also contains a JSR223
+PreProcessor that appears to do this, but cannot — a PreProcessor runs when a sampler
+fires, after the thread group has already read its schedule.
+
 ## Report Output
 
-Each test execution generates timestamped reports:
+Each run writes a self-contained directory, `reports/<run_id>/`:
 
 ```
-reports/
-  results_YYYYMMDD-HHMMSS.jtl          # Raw JMeter results (CSV)
-  AggregateReport_YYYYMMDD-HHMMSS.csv  # Per-query statistics
-  statistics_YYYYMMDD-HHMMSS.json      # JSON summary for automation
-  test_result_YYYYMMDD-HHMMSS.json     # Test metadata
-  dashboard_YYYYMMDD-HHMMSS/           # HTML dashboard (if enabled)
+reports/20260807-180031/
+  JmeterResultFile.csv                 # raw per-sample results
+  AggregateReport.csv                  # per-query statistics
+  SummaryReport.csv                    # summary statistics
+  statistics.json                      # JMeter aggregate stats
+  run_report.md                        # human-readable summary (auto-generated)
+  run_summary.json                     # machine-readable metrics (auto-generated)
+  <plan>-generated.jmx                 # the exact plan that ran (load-profile runs)
+  dashboard/                           # HTML dashboard (unless disabled)
 ```
 
-Set `GENERATE_DASHBOARD=false` in test properties to skip HTML generation (saves ~50-100MB per test).
+`run_report.md` and `run_summary.json` are produced automatically by
+`utilities/capture_run_report.py` after every run — throughput, percentiles, drain time,
+queue build-up, and, for load-profile runs, delivered-vs-expected arrivals with a
+`SHORTFALL` verdict when arrivals were dropped.
+
+Set `GENERATE_DASHBOARD=false` to skip HTML generation — roughly 3.5 MB of vendored
+assets per run:
+
+```bash
+GENERATE_DASHBOARD=false ./run_jmeter_tests_interactive.sh
+```
+
+The S3 upload always omits those vendored assets (9 objects instead of 129); set
+`S3_UPLOAD_DASHBOARD_ASSETS=true` to include them.
 
 ## Common Development Tasks
 
@@ -531,6 +597,47 @@ java -version  # Verify
 2. Check connection string format for your database
 3. Use test script: `./utilities/test_jdbc_connection.sh connection.properties`
 4. Check JMeter logs in `apache-jmeter-5.6.3/bin/jmeter.log`
+
+### Load Profile Not Applied
+
+If a load-profile run produces far fewer samples than expected (classically exactly the
+number of queries in your CSV), check for the `load profile applied:` line at the start of
+the run. Without it the plan fell back to its built-in schedule. Confirm `LOAD_PROFILE`
+points at an existing file — a missing file is now a hard error rather than a silent
+fallback.
+
+If arrivals fall short *within* the profile window, `MAX_CONCURRANCY` is too low and the
+arrivals thread group dropped them. `run_report.md` flags this as `SHORTFALL`.
+
+### Databricks: ExceptionInInitializerError on Java 9+
+
+Every query fails immediately with `java.lang.ExceptionInInitializerError`. The Databricks
+driver bundles Apache Arrow, whose off-heap memory layer reflectively accesses
+`java.nio.DirectByteBuffer` internals. JMeter's launcher does not open `java.base/java.nio`,
+so Arrow's static initialiser fails. Either append to the connection string:
+
+```
+;EnableArrow=0
+```
+
+or keep Arrow and grant the module access on every run:
+
+```bash
+export JVM_ARGS="--add-opens=java.base/java.nio=ALL-UNNAMED"
+```
+
+### UNIMPLEMENTED: No cluster-name header or unknown cluster
+
+More than one `e6-jdbc-driver-*.jar` is on the classpath and an older one is winning. Load
+order depends on the filesystem, so this can reproduce on Linux but not macOS:
+
+```bash
+find apache-jmeter-5.6.3 -name "e6-jdbc-driver-*.jar"   # expect exactly one
+./utilities/fix_jmeter_jar_conflicts.sh
+```
+
+The same message also appears when the cluster is suspended — a suspended e6data cluster
+auto-resumes on first contact, and the first run afterwards can fail while it comes up.
 
 ### S3 Upload Failures
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/CLAUDE.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/CLAUDE.md
@@ -506,7 +506,7 @@ Afterwards `run_report.md` scores the run against the profile:
 
 - **arrival rate** — delivered vs expected arrivals. `SHORTFALL` means `MAX_CONCURRANCY`
   was too low.
-- **concurrency** — how many seconds in-flight stayed within 1 of the profile. A brief
+- **concurrency** — how many seconds peak query-in-flight stayed within the documented tolerance of the profile. A brief
   overshoot at a wave boundary is expected: a thread finishes its current query before
   stopping, so the outgoing and incoming waves overlap for a few seconds.
 
@@ -589,7 +589,7 @@ To enable batch testing for a new engine/cluster/benchmark combination:
    ```bash
    cp metadata_files/e6data_s-2x2_metadata.txt metadata_files/my_engine_my-cluster_metadata.txt
    ```
-   Edit cluster configuration JSON, S3 settings, and `S3_BASE_PATH`
+   Edit cluster configuration JSON, S3 settings, and `S3_REPORT_PATH` (`S3_BASE_PATH` is a legacy metadata alias)
 
 2. **Create connection properties** (if not exists):
    ```bash
@@ -717,6 +717,6 @@ auto-resumes on first contact, and the first run afterwards can fail while it co
 ### S3 Upload Failures
 
 1. Ensure AWS credentials configured: `aws s3 ls s3://your-bucket/`
-2. Check `S3_BASE_PATH` in metadata file
+2. Check `S3_REPORT_PATH` in the runner configuration (or legacy `S3_BASE_PATH` in metadata)
 3. Verify `COPY_TO_S3=true` in test properties
 4. Check logs in `/tmp/jmeter_test_logs/`

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/README.md
@@ -141,17 +141,30 @@ export CONCURRENT_QUERY_COUNT=8
 
 ### Load profile CSV
 
-For load-profile-based test plans, edit `test_properties/load_profile.csv`:
+The two load-profile plans control different things, so they take different CSV formats.
+The format is picked from the plan automatically — set `LOAD_PROFILE` to any CSV.
+
+**Arrival rate** — `Test-Plan-Fire-QPS-with-load-profile.jmx`, default
+`test_properties/load_profile.csv`. Controls how fast queries are *submitted*:
 
 ```csv
 StartValue,EndValue,Duration
-1,1,5
-2,2,10
-4,4,10
-2,2,5
+1,1,5        # 1 QPS for 5s
+2,2,10       # 2 QPS for 10s
+1,10,5       # ramp 1 -> 10 QPS over 5s
 ```
 
-Each row: hold `StartValue`-to-`EndValue` concurrency/QPS/QPM for `Duration` seconds.
+**Concurrency** — `Test-Plan-Maintain-variable-concurrency-with-load-profile.jmx`, default
+`test_properties/utg_load_profile.csv`. Controls how many run *at once*. Rows stack:
+
+```csv
+Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+10,0,30,60,10     # ramp to 10 over 30s, hold 60s, wind down over 10s
+20,90,30,60,10    # +20 more from t=90 -> 30 concurrent
+```
+
+Use `StartupTime=0` and `ShutdownTime=0` for a flat step with no ramp. All times in seconds.
+See `CLAUDE.md` for the full reference.
 
 ## Configuration Reference
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/README.md
@@ -13,12 +13,26 @@ export HOLD_PERIOD=600    # change duration from 300 to 600
 
 Helper scripts (`create_connection.sh`, `create_test_config.sh`) interactively create the `.properties` and `.env` config files you need.
 
+## What this framework measures
+
+This is a **JMeter-based benchmark framework and orchestration wrapper**. JMeter supplies scheduling, threads, timers, JDBC/HTTP samplers, and raw client timings; the repository adds reusable plans, configuration precedence, load-profile injection, result packaging, failure thresholds, and comparison/reporting utilities.
+
+It is suitable for measuring:
+
+- client-observed query latency and throughput;
+- fixed and variable concurrent query behavior;
+- constant QPS/QPM and ramped arrival-rate behavior;
+- queue build-up, saturation, drain time, and error behavior;
+- repeatable comparisons across engines or builds.
+
+JMeter measures the workload from the client. Its `elapsed` value includes driver/network/fetch time as well as engine work. For engine-only analysis, correlate each sample's query ID with engine execution, planning, queue, scan, spill, and cache metrics. Keep result fetching and row limits identical across engines, and separate cold-cache, warm-cache, and sustained-load runs.
+
 ## Steps to Run
 
 ### Step 1: Install JMeter and dependencies
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/e6data/e6-public-benchmarks.git
 cd e6-public-benchmarks/jmeter_benchmarks/jmeter-jdbc-test-framework
 
 # Installs Java 17, JMeter 5.6.3, plugins, and Groovy 4.0.29
@@ -39,7 +53,7 @@ This creates a file in `connection_properties/` — e.g., `connection_properties
 
 ### Step 3: Create your queries CSV file
 
-Create a CSV file in `data_files/` with one query per row:
+Create `data_files/` (it is intentionally ignored because workloads may be sensitive), then add a CSV with one query per row:
 
 ```csv
 query_alias,query_string
@@ -48,12 +62,56 @@ q2,"SELECT col1, col2 FROM my_table WHERE col1 > 100"
 ```
 
 ```bash
+mkdir -p data_files
 cp my_queries.csv data_files/
 ```
 
 ### Step 4: Run a test
 
-**Option A — Export variables and run (recommended):**
+**Option A — One reusable config, choose the load model at runtime (recommended):**
+
+```bash
+cp test_configs/sample_benchmark.env test_configs/my_benchmark.env
+# Edit CONNECTION_FILE and QUERY_FILE once in my_benchmark.env.
+```
+
+The following commands reuse that file and change only the plan plus its controlling parameters:
+
+```bash
+# Run every query once at concurrency 1
+TEST_PLAN=Test-Plans/Test-Plan-Run-Once-static-concurrency.jmx \
+  CONCURRENT_QUERY_COUNT=1 RECYCLE_ON_EOF=false \
+  ./run_test.sh test_configs/my_benchmark.env
+
+# Hold four queries in flight for five minutes
+TEST_PLAN=Test-Plans/Test-Plan-Maintain-static-concurrency.jmx \
+  CONCURRENT_QUERY_COUNT=4 HOLD_PERIOD=300 \
+  ./run_test.sh test_configs/my_benchmark.env
+
+# Submit five queries per second for five minutes
+TEST_PLAN=Test-Plans/Test-Plan-Constant-QPS-On-Arrivals-JSR-Optimized.jmx \
+  QPS=5 HOLD_PERIOD=300 \
+  ./run_test.sh test_configs/my_benchmark.env
+
+# Submit 60 queries per minute; this plan interprets HOLD_PERIOD as minutes
+TEST_PLAN=Test-Plans/Test-Plan-Constant-QPM-On-Arrivals.jmx \
+  QPM=60 HOLD_PERIOD=5 \
+  ./run_test.sh test_configs/my_benchmark.env
+
+# Vary arrivals/QPS using a 3-column CSV
+TEST_PLAN=Test-Plans/Test-Plan-Fire-QPS-with-load-profile.jmx \
+  LOAD_PROFILE=test_properties/load_profile.csv \
+  ./run_test.sh test_configs/my_benchmark.env
+
+# Vary concurrent queries using a 5-column CSV
+TEST_PLAN=Test-Plans/Test-Plan-Maintain-variable-concurrency-with-load-profile.jmx \
+  LOAD_PROFILE=test_properties/utg_load_profile.csv \
+  ./run_test.sh test_configs/my_benchmark.env
+```
+
+Environment values override the config file, so no JMX editing or separate config per load level is required.
+
+**Option B — Export variables and run:**
 
 ```bash
 export CONNECTION_FILE=connection_properties/my_connection.properties
@@ -67,7 +125,7 @@ export HOLD_PERIOD=300
 
 Change any variable and re-run — no prompts, no file editing.
 
-**Option B — Use a config file:**
+**Option C — Use a dedicated config file:**
 
 ```bash
 # Copy sample and edit
@@ -78,7 +136,7 @@ vi test_configs/my_test.env
 ./run_test.sh test_configs/my_test.env
 ```
 
-**Option C — Fully interactive:**
+**Option D — Fully interactive:**
 
 ```bash
 ./run_jmeter_tests_interactive.sh
@@ -134,10 +192,13 @@ export CONCURRENT_QUERY_COUNT=8
 | `CONCURRENT_QUERY_COUNT` | Number of simultaneous queries | Concurrency-based plans |
 | `QPS` | Queries per second | QPS-based plans |
 | `QPM` | Queries per minute | QPM-based plans |
-| `HOLD_PERIOD` | Test duration in seconds | All plans except Run-Once |
+| `HOLD_PERIOD` | Test duration in seconds; the QPM arrivals plan interprets it as minutes | All plans except Run-Once |
 | `RECYCLE_ON_EOF` | Repeat queries when CSV ends (`true`/`false`) | All plans |
 | `RANDOM_ORDER` | Shuffle query execution order (`true`/`false`) | All plans |
 | `COPY_TO_S3` | Upload results to S3 (`true`/`false`, default `false`) | All plans |
+| `S3_REPORT_PATH` | Root path for runner uploads; `S3_BASE_PATH` remains a legacy metadata alias | All plans |
+| `RUN_TYPE` | Optional S3 partition label; inferred from plan and concurrency/rate when omitted | All plans |
+| `MAX_ERROR_PCT` | Exit nonzero when sample error percentage exceeds this value | All plans |
 
 ### Load profile CSV
 
@@ -180,6 +241,7 @@ See `CLAUDE.md` for the full reference.
 
 Ready-to-copy templates in `test_configs/`:
 
+- `sample_benchmark.env` — one reusable config for all JDBC load models
 - `sample_concurrency_test.env` — static concurrency test
 - `sample_qps_test.env` — constant QPS test
 
@@ -197,15 +259,14 @@ cp test_configs/sample_concurrency_test.env test_configs/my_test.env
 ├── run_test.sh                      # Run test (config file or env vars)
 ├── run_jmeter_tests_interactive.sh  # Run test (interactive)
 ├── connection_properties/           # JDBC connection files
-│   └── sample_connection.properties
+│   └── connection.properties.template
 ├── test_properties/                 # Test parameter files
-│   ├── sample_test.properties
+│   ├── test.properties.template
 │   └── load_profile.csv
 ├── test_configs/                    # Ready-to-run config files
 │   ├── sample_concurrency_test.env
 │   └── sample_qps_test.env
-├── data_files/                      # Query CSV files
-│   └── sample_jmeter_queries.csv
+├── data_files/                      # Local query CSV files (ignored; create it)
 ├── Test-Plans/                      # JMeter test plan files (.jmx)
 ├── jdbc_drivers/                    # JDBC driver JARs
 ├── metadata_files/                  # Cluster metadata for S3/Athena
@@ -229,7 +290,27 @@ Set `GENERATE_DASHBOARD=false` to skip the HTML dashboard (~3.5 MB per run).
 
 These can be opened in spreadsheet tools or processed with the scripts in `utilities/`.
 
+`run_summary.json` distinguishes raw JMeter samples from query samples, records ignored framework-control samples, and captures the requested load settings, query/profile checksums, original/generated plan names, Java/JMeter versions, and Git commit. This metadata is intended to make historical runs reproducible.
+
 For analysis and comparison tools, see [utilities/README.md](utilities/README.md).
+
+S3 uploads use the common partition layout `engine=.../cluster_size=.../benchmark=.../run_type=.../run_id=.../`. Set `S3_REPORT_PATH` to its root. Existing metadata that defines `S3_BASE_PATH` is supported as a deprecated alias.
+
+## Developer checks
+
+Run the dependency-free regression suite and static checks before changing runners, profile parsing, or reporting:
+
+```bash
+python3 -m unittest discover -s utilities/tests -v
+./utilities/run_premerge_checks.sh
+```
+
+For a bounded live JDBC validation (five plans, real query load):
+
+```bash
+./utilities/run_smoke_suite.sh \
+  connection_properties/my_connection.properties data_files/my_queries.csv
+```
 
 ## Important Notes
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/README.md
@@ -204,9 +204,15 @@ cp test_configs/sample_concurrency_test.env test_configs/my_test.env
 
 Each test run generates results in the `reports/` directory:
 
-- **JTL file** (`results.jtl`) — raw CSV with per-query timing (timestamp, elapsed ms, label, success)
-- **Aggregate report** (`AggregateReport_TIMESTAMP.csv`) — same data with timestamped filename
-- **Dashboard** (`statistics.json`) — summary statistics when dashboard generation is enabled
+Each run gets its own directory, `reports/<run_id>/`, containing:
+
+- **`JmeterResultFile.csv`** — raw CSV with per-query timing (timestamp, elapsed ms, label, success)
+- **`AggregateReport.csv`** / **`SummaryReport.csv`** — per-query and summary statistics
+- **`run_report.md`** — human-readable summary, generated automatically after every run
+- **`run_summary.json`** — the same metrics in machine-readable form
+- **`statistics.json`** and **`dashboard/`** — JMeter's aggregate stats and HTML dashboard
+
+Set `GENERATE_DASHBOARD=false` to skip the HTML dashboard (~3.5 MB per run).
 
 These can be opened in spreadsheet tools or processed with the scripts in `utilities/`.
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/Test-Plans/Test-Plan-Maintain-static-concurrency.jmx
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/Test-Plans/Test-Plan-Maintain-static-concurrency.jmx
@@ -123,6 +123,7 @@
           </elementProp>
         </collectionProp>
       </elementProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
     </TestPlan>
     <hashTree>
       <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report">
@@ -164,7 +165,7 @@
         <stringProp name="filename">${REPORT_PATH}/AggregateReport_${START_TIME}.csv</stringProp>
       </ResultCollector>
       <hashTree/>
-      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report">
+      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>
@@ -203,7 +204,7 @@
         <stringProp name="filename">${REPORT_PATH}/SummaryReport_${START_TIME}.csv</stringProp>
       </ResultCollector>
       <hashTree/>
-      <JDBCDataSource guiclass="TestBeanGUI" testclass="JDBCDataSource" testname="JDBC Connection Configuration">
+      <JDBCDataSource guiclass="TestBeanGUI" testclass="JDBCDataSource" testname="JDBC Connection Configuration" enabled="true">
         <boolProp name="autocommit">true</boolProp>
         <stringProp name="checkQuery"></stringProp>
         <stringProp name="connectionAge">300000</stringProp>
@@ -223,9 +224,9 @@
         <stringProp name="poolPreparedStatements">5</stringProp>
       </JDBCDataSource>
       <hashTree/>
-      <ConfigTestElement guiclass="PropertyControlGui" testclass="ConfigTestElement" testname="Property Display"/>
+      <ConfigTestElement guiclass="PropertyControlGui" testclass="ConfigTestElement" testname="Property Display" enabled="true"/>
       <hashTree/>
-      <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config">
+      <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config" enabled="true">
         <stringProp name="filename">${QUERY_PATH}</stringProp>
         <stringProp name="fileEncoding">US-ASCII</stringProp>
         <stringProp name="variableNames">QUERY_ALIAS,QUERY</stringProp>
@@ -237,7 +238,7 @@
         <stringProp name="shareMode">shareMode.group</stringProp>
       </CSVDataSet>
       <hashTree/>
-      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group">
+      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group" enabled="true">
         <intProp name="ThreadGroup.num_threads">1</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
@@ -426,7 +427,7 @@ if (&quot;false&quot;.equals(props.get(&quot;RECYCLE_ON_EOF&quot;)) &amp;&amp; (
 }</stringProp>
         </JSR223PreProcessor>
         <hashTree/>
-        <JDBCSampler guiclass="TestBeanGUI" testclass="JDBCSampler" testname="${QUERY_ALIAS}">
+        <JDBCSampler guiclass="TestBeanGUI" testclass="JDBCSampler" testname="${QUERY_ALIAS}" enabled="true">
           <stringProp name="dataSource">jdbcConfig</stringProp>
           <stringProp name="query">${QUERY}</stringProp>
           <stringProp name="queryArguments"></stringProp>
@@ -451,7 +452,7 @@ if (&quot;false&quot;.equals(props.get(&quot;RECYCLE_ON_EOF&quot;)) &amp;&amp; (
         </elementProp>
       </PostThreadGroup>
       <hashTree>
-        <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor">
+        <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
           <stringProp name="cacheKey">false</stringProp>
           <stringProp name="filename"></stringProp>
           <stringProp name="parameters"></stringProp>
@@ -460,7 +461,7 @@ if (&quot;false&quot;.equals(props.get(&quot;RECYCLE_ON_EOF&quot;)) &amp;&amp; (
         </JSR223PostProcessor>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/Test-Plans/Test-Plan-Maintain-static-concurrency.jmx
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/Test-Plans/Test-Plan-Maintain-static-concurrency.jmx
@@ -123,7 +123,6 @@
           </elementProp>
         </collectionProp>
       </elementProp>
-      <boolProp name="TestPlan.functional_mode">false</boolProp>
     </TestPlan>
     <hashTree>
       <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report">
@@ -165,7 +164,7 @@
         <stringProp name="filename">${REPORT_PATH}/AggregateReport_${START_TIME}.csv</stringProp>
       </ResultCollector>
       <hashTree/>
-      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>
@@ -204,7 +203,7 @@
         <stringProp name="filename">${REPORT_PATH}/SummaryReport_${START_TIME}.csv</stringProp>
       </ResultCollector>
       <hashTree/>
-      <JDBCDataSource guiclass="TestBeanGUI" testclass="JDBCDataSource" testname="JDBC Connection Configuration" enabled="true">
+      <JDBCDataSource guiclass="TestBeanGUI" testclass="JDBCDataSource" testname="JDBC Connection Configuration">
         <boolProp name="autocommit">true</boolProp>
         <stringProp name="checkQuery"></stringProp>
         <stringProp name="connectionAge">300000</stringProp>
@@ -224,9 +223,9 @@
         <stringProp name="poolPreparedStatements">5</stringProp>
       </JDBCDataSource>
       <hashTree/>
-      <ConfigTestElement guiclass="PropertyControlGui" testclass="ConfigTestElement" testname="Property Display" enabled="true"/>
+      <ConfigTestElement guiclass="PropertyControlGui" testclass="ConfigTestElement" testname="Property Display"/>
       <hashTree/>
-      <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config" enabled="true">
+      <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config">
         <stringProp name="filename">${QUERY_PATH}</stringProp>
         <stringProp name="fileEncoding">US-ASCII</stringProp>
         <stringProp name="variableNames">QUERY_ALIAS,QUERY</stringProp>
@@ -238,7 +237,7 @@
         <stringProp name="shareMode">shareMode.group</stringProp>
       </CSVDataSet>
       <hashTree/>
-      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group" enabled="true">
+      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group">
         <intProp name="ThreadGroup.num_threads">1</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
@@ -427,7 +426,7 @@ if (&quot;false&quot;.equals(props.get(&quot;RECYCLE_ON_EOF&quot;)) &amp;&amp; (
 }</stringProp>
         </JSR223PreProcessor>
         <hashTree/>
-        <JDBCSampler guiclass="TestBeanGUI" testclass="JDBCSampler" testname="${QUERY_ALIAS}" enabled="true">
+        <JDBCSampler guiclass="TestBeanGUI" testclass="JDBCSampler" testname="${QUERY_ALIAS}">
           <stringProp name="dataSource">jdbcConfig</stringProp>
           <stringProp name="query">${QUERY}</stringProp>
           <stringProp name="queryArguments"></stringProp>
@@ -452,7 +451,7 @@ if (&quot;false&quot;.equals(props.get(&quot;RECYCLE_ON_EOF&quot;)) &amp;&amp; (
         </elementProp>
       </PostThreadGroup>
       <hashTree>
-        <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
+        <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor">
           <stringProp name="cacheKey">false</stringProp>
           <stringProp name="filename"></stringProp>
           <stringProp name="parameters"></stringProp>
@@ -461,7 +460,7 @@ if (&quot;false&quot;.equals(props.get(&quot;RECYCLE_ON_EOF&quot;)) &amp;&amp; (
         </JSR223PostProcessor>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/jdbc_drivers/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/jdbc_drivers/README.md
@@ -1,40 +1,33 @@
 # JDBC Drivers
 
-This directory contains custom JDBC drivers that are copied to `apache-jmeter-5.6.3/lib/ext/` during setup.
+The repository currently includes the e6data JDBC driver used by the checked-in test setup. Additional JDBC JARs placed here are ignored by Git. `./setup_jmeter.sh` copies third-party drivers and only the highest-versioned e6data driver into JMeter's `lib/ext/` directory.
 
-## Included Drivers
+## Bundled artifact
 
-- **E6Data JDBC Driver** (`e6-jdbc-driver-1.2.82-with-dependencies.jar`) - 27MB
-  - Driver class: `io.e6.jdbc.driver.E6Driver`
+| File | SHA-256 |
+|---|---|
+| `e6-jdbc-driver-2.0.27-with-dependencies.jar` | `9dc81088a0604616ec32676ee5146ee717dc511d48cd0583da68e41097a6a10b` |
 
-- **Trino JDBC Driver** (`trino-jdbc-474.jar`) - 12MB
-  - Driver class: `io.trino.jdbc.TrinoDriver`
+The checksum verifies repository/download integrity; it does not establish provenance. Maintainers should verify the binary against the approved internal or vendor release source before publishing a release. When upgrading it, update this checksum and record the source release in the pull request.
 
-- **Presto JDBC Driver** (`presto-jdbc-0.283.jar`) - 9.4MB
-  - Driver class: `com.facebook.presto.jdbc.PrestoDriver`
+The setup script copies JARs from this directory into `apache-jmeter-5.6.3/lib/ext/`. Obtain drivers from the database vendor and verify that their licenses permit your intended use and redistribution.
 
-- **AWS Athena JDBC Driver** (`athena-jdbc-3.0.0-with-dependencies.jar`) - 18MB
-  - Driver class: `com.simba.athena.jdbc.Driver`
+## Common driver classes
 
-## Adding New Drivers
+| Engine | Driver class |
+|---|---|
+| e6data | `io.e6.jdbc.driver.E6Driver` |
+| Trino | `io.trino.jdbc.TrinoDriver` |
+| Presto | `com.facebook.presto.jdbc.PrestoDriver` |
+| Amazon Athena (Simba) | `com.simba.athena.jdbc.Driver` |
 
-To add a new JDBC driver:
+For Databricks, download the current JDBC driver from Databricks and use the driver class documented for that release. Driver packaging and class names can change, so the vendor documentation is the source of truth.
 
-1. Place the JAR file in this directory
-2. Run `./setup_jmeter.sh` to copy it to JMeter's lib/ext/
-3. Commit the JAR file to git (if it's a custom or hard-to-obtain driver)
+## Add or update a driver
 
-For publicly available drivers (like DBR), consider adding download logic to `setup_jmeter.sh` instead of committing large JARs.
+1. Download the JAR from the vendor.
+2. Place it in this directory.
+3. Run `./setup_jmeter.sh`.
+4. Run `utilities/test_jdbc_connection.sh` before starting a load test.
 
-## DBR JDBC Driver
-
-The DBR JDBC driver is NOT included here due to its size and licensing.
-
-To use DBR:
-1. Download from: https://www.dbr.com/spark/jdbc-drivers-download
-2. Place `DBRJDBC42-*.jar` in `apache-jmeter-5.6.3/lib/ext/`
-3. Driver class: `com.dbr.client.jdbc.Driver`
-
-## Total Size
-
-Current total: ~67MB (4 drivers)
+Do not commit credentials or additional driver binaries without an explicit licensing and provenance review. If multiple versions of the same driver are installed, use `utilities/fix_jmeter_jar_conflicts.sh --dry-run` to identify classpath conflicts before making changes.

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -433,6 +433,30 @@ if [ -n "$METADATA_FILE" ]; then
 fi
 echo ""
 
+# Show the endpoint being tested. The filename alone does not say which cluster
+# the run will hit, which matters when several files point at similar clusters.
+# Any password embedded in the URL is redacted.
+echo -e "${DIM}Target:${NC}"
+if [ "$CONN_TYPE" = "http" ]; then
+    _host=$(grep -E "^mainhost=" "$CONNECTION_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+    [ -n "$_host" ] && echo "  Host:            ${_host}"
+else
+    _url=$(grep -E "^CONNECTION_STRING=" "$CONNECTION_FILE" 2>/dev/null | head -1 | cut -d= -f2- \
+           | sed -E 's/([Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]=)[^&]*/\1<redacted>/g')
+    _user=$(grep -E "^USER=" "$CONNECTION_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+    if [ -n "$_url" ]; then
+        echo "  JDBC URL:        ${_url}"
+        # cluster-name is the parameter that decides which cluster serves the query
+        case "$_url" in
+            *cluster-name=*) echo "  Cluster:         $(echo "$_url" | sed -E 's/.*cluster-name=([^&]*).*/\1/')" ;;
+        esac
+    else
+        echo -e "  ${YELLOW}No CONNECTION_STRING found in $(basename "$CONNECTION_FILE")${NC}"
+    fi
+    [ -n "$_user" ] && echo "  User:            ${_user}"
+fi
+echo ""
+
 # Show key test parameters from properties file
 echo -e "${DIM}Key parameters from test properties:${NC}"
 grep -E "^(CONCURRENT_QUERY_COUNT|QPS|QPM|HOLD_PERIOD|COPY_TO_S3|RECYCLE_ON_EOF)=" "$TEST_PROPERTIES" 2>/dev/null | while read -r line; do
@@ -461,20 +485,23 @@ echo ""
 # Build and run JMeter command
 # ============================================================================
 
-# Source metadata for runtime variables if present
-if [ -n "$METADATA_FILE" ]; then
-    source "$METADATA_FILE"
-fi
-
-# Values set in the environment win over the properties file, so a single
-# properties file can be reused across runs:
+# Values set in the environment win over both the metadata file and the
+# properties file, so a single config can be reused across runs:
 #   LOAD_PROFILE=test_properties/spike.csv ./run_jmeter_tests_interactive.sh
 # Matches the precedence run_test.sh already implements.
+#
+# Captured BEFORE the metadata is sourced: metadata defines COPY_TO_S3 and
+# would otherwise overwrite the environment value before it could be saved.
 OVERRIDABLE="LOAD_PROFILE HOLD_PERIOD MAX_CONCURRANCY COPY_TO_S3 RECYCLE_ON_EOF \
 RANDOM_ORDER QPS QPM CONCURRENT_QUERY_COUNT RAMP_UP_TIME RAMP_UP_STEPS QUERY_TIMEOUT"
 for _k in $OVERRIDABLE; do
     [ -n "${!_k:-}" ] && printf -v "_ENV_$_k" '%s' "${!_k}"
 done
+
+# Source metadata for runtime variables if present
+if [ -n "$METADATA_FILE" ]; then
+    source "$METADATA_FILE"
+fi
 
 # Read test properties without executing them (values like
 # threads_schedule=spawn(4,0s,...) are not valid bash)
@@ -601,7 +628,18 @@ if [ "${COPY_TO_S3:-false}" = "true" ] && [ -n "${S3_BASE_PATH:-}" ]; then
     S3_DEST="${S3_BASE_PATH}/engine=${ENGINE_VAL}/cluster_size=${CLUSTER_SIZE_VAL}/benchmark=${BENCHMARK_VAL}/${RUN_TYPE_VAL}/run_id=${TIMESTAMP}/"
 
     echo "  S3 path: ${S3_DEST}"
-    aws s3 cp "${REPORT_DIR}/" "${S3_DEST}" --recursive
+    # The JMeter HTML dashboard vendors jQuery/Bootstrap/font-awesome/flot -
+    # ~120 files and ~3.5MB per run, byte-identical every time and read by
+    # nothing downstream. Upload the data and the dashboard pages, skip the
+    # vendored assets. Set S3_UPLOAD_DASHBOARD_ASSETS=true to include them.
+    if [ "${S3_UPLOAD_DASHBOARD_ASSETS:-false}" = "true" ]; then
+        aws s3 cp "${REPORT_DIR}/" "${S3_DEST}" --recursive
+    else
+        aws s3 cp "${REPORT_DIR}/" "${S3_DEST}" --recursive \
+            --exclude "dashboard/sbadmin2-1.0.7/*" \
+            --exclude "dashboard/content/css/*" \
+            --exclude "dashboard/content/js/*"
+    fi
     echo -e "  ${GREEN}Uploaded to S3${NC}"
 fi
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -36,6 +36,36 @@ METADATA_DIR="metadata_files"
 # Helper functions
 # ============================================================================
 
+# Match an answer against a file list, by number OR by filename.
+# Filenames are what scripted callers should use: list positions shift whenever a
+# file is added to the directory, so a piped number silently selects the wrong
+# file, while a filename keeps meaning the same thing.
+# Accepts: "3" | "e6data_test_connection.properties" | "e6data_test_connection"
+#          | "connection_properties/e6data_test_connection.properties"
+# Sets MATCHED_FILE, returns 0 on success.
+match_choice() {
+    local answer="$1"; shift
+    local files=("$@")
+    local count=${#files[@]}
+
+    if [[ "$answer" =~ ^[0-9]+$ ]] && [ "$answer" -ge 1 ] && [ "$answer" -le "$count" ]; then
+        MATCHED_FILE="${files[$((answer - 1))]}"
+        return 0
+    fi
+
+    local want
+    want=$(basename "$answer")
+    for f in "${files[@]}"; do
+        local b
+        b=$(basename "$f")
+        if [ "$b" = "$want" ] || [ "${b%.*}" = "$want" ]; then
+            MATCHED_FILE="$f"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Display a numbered list and get user selection
 # Usage: select_file "prompt" file1 file2 file3 ...
 # Returns: selected file path in SELECTED_FILE variable
@@ -57,12 +87,12 @@ select_file() {
     echo ""
 
     while true; do
-        read -p "Enter choice [1-${count}]: " choice
-        if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$count" ]; then
-            SELECTED_FILE="${files[$((choice - 1))]}"
+        read -p "Enter choice [1-${count}] or filename: " choice
+        if match_choice "$choice" "${files[@]}"; then
+            SELECTED_FILE="$MATCHED_FILE"
             return 0
         fi
-        echo -e "${RED}Invalid choice. Enter a number between 1 and ${count}.${NC}"
+        echo -e "${RED}Invalid choice. Enter a number between 1 and ${count}, or a filename from the list.${NC}"
     done
 }
 
@@ -195,15 +225,15 @@ fi
 echo ""
 
 while true; do
-    read -p "Enter choice [N or 1-${#TEST_PROPS_FILES[@]}]: " props_choice
+    read -p "Enter choice [N or 1-${#TEST_PROPS_FILES[@]}] or filename: " props_choice
     if [[ "$props_choice" =~ ^[Nn]$ ]]; then
         break
     fi
-    if [ ${#TEST_PROPS_FILES[@]} -gt 0 ] && [[ "$props_choice" =~ ^[0-9]+$ ]] && [ "$props_choice" -ge 1 ] && [ "$props_choice" -le ${#TEST_PROPS_FILES[@]} ]; then
-        TEST_PROPERTIES="${TEST_PROPS_FILES[$((props_choice - 1))]}"
+    if [ ${#TEST_PROPS_FILES[@]} -gt 0 ] && match_choice "$props_choice" "${TEST_PROPS_FILES[@]}"; then
+        TEST_PROPERTIES="$MATCHED_FILE"
         break
     fi
-    echo -e "${RED}Invalid choice. Enter N for new or a number.${NC}"
+    echo -e "${RED}Invalid choice. Enter N for new, a number, or a filename from the list.${NC}"
 done
 
 # Create new test properties if selected
@@ -399,17 +429,22 @@ if [ ${#METADATA_FILES[@]} -gt 0 ]; then
 fi
 echo ""
 
+METADATA_FILE=""
 while true; do
-    read -p "Enter choice [0-${#METADATA_FILES[@]}]: " meta_choice
-    if [[ "$meta_choice" =~ ^[0-9]+$ ]] && [ "$meta_choice" -ge 0 ] && [ "$meta_choice" -le ${#METADATA_FILES[@]} ]; then
+    read -p "Enter choice [0-${#METADATA_FILES[@]}] or filename: " meta_choice
+    if [ "$meta_choice" = "0" ] || [[ "$meta_choice" =~ ^([Ss]kip|[Nn]one)$ ]]; then
+        meta_choice=0
         break
     fi
-    echo -e "${RED}Invalid choice.${NC}"
+    if [ ${#METADATA_FILES[@]} -gt 0 ] && match_choice "$meta_choice" "${METADATA_FILES[@]}"; then
+        METADATA_FILE="$MATCHED_FILE"
+        meta_choice=1
+        break
+    fi
+    echo -e "${RED}Invalid choice. Enter 0 to skip, a number, or a filename from the list.${NC}"
 done
 
-METADATA_FILE=""
 if [ "$meta_choice" -gt 0 ]; then
-    METADATA_FILE="${METADATA_FILES[$((meta_choice - 1))]}"
     echo -e "  ${GREEN}Selected: $(basename "$METADATA_FILE")${NC}"
 else
     echo -e "  ${DIM}Skipped${NC}"
@@ -492,7 +527,7 @@ echo ""
 #
 # Captured BEFORE the metadata is sourced: metadata defines COPY_TO_S3 and
 # would otherwise overwrite the environment value before it could be saved.
-OVERRIDABLE="LOAD_PROFILE HOLD_PERIOD MAX_CONCURRANCY COPY_TO_S3 RECYCLE_ON_EOF \
+OVERRIDABLE="LOAD_PROFILE GENERATE_DASHBOARD HOLD_PERIOD MAX_CONCURRANCY COPY_TO_S3 RECYCLE_ON_EOF \
 RANDOM_ORDER QPS QPM CONCURRENT_QUERY_COUNT RAMP_UP_TIME RAMP_UP_STEPS QUERY_TIMEOUT"
 for _k in $OVERRIDABLE; do
     [ -n "${!_k:-}" ] && printf -v "_ENV_$_k" '%s' "${!_k}"
@@ -579,7 +614,11 @@ JMETER_CMD=("$JMETER_HOME/bin/jmeter" -n)
 JMETER_CMD+=(-t "$TEST_PLAN")
 JMETER_CMD+=(-q "$CONNECTION_FILE")
 JMETER_CMD+=(-l "${REPORT_DIR}/JmeterResultFile.csv")
-JMETER_CMD+=(-e -o "${REPORT_DIR}/dashboard")
+# HTML dashboard is ~3.5MB of vendored assets per run. CLAUDE.md documents
+# GENERATE_DASHBOARD=false to skip it; honour that here.
+if [ "${GENERATE_DASHBOARD:-true}" != "false" ]; then
+    JMETER_CMD+=(-e -o "${REPORT_DIR}/dashboard")
+fi
 
 # Add all properties as JMeter parameters
 JMETER_CMD+=("-JCONNECTION_PROPERTIES=$CONNECTION_FILE")

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -158,7 +158,7 @@ if [ "$CONN_TYPE" = "jdbc" ]; then
     echo "  3) Constant QPS              - Fire queries at N per second"
     echo "  4) Constant QPM              - Fire queries at N per minute"
     echo "  5) QPS with Load Profile     - Variable QPS from CSV schedule"
-    echo "  6) Variable Concurrency      - Custom thread spawn schedule"
+    echo "  6) Variable Concurrency      - Variable concurrency from CSV schedule"
     echo ""
 
     while true; do
@@ -308,12 +308,25 @@ if [[ "$props_choice" =~ ^[Nn]$ ]]; then
             ;;
         variable_concurrency)
             echo ""
-            echo "Enter thread spawn schedule using UTG format:"
-            echo -e "${DIM}  Format: spawn(threads, initialDelay, startupTime, holdFor, shutdownTime)${NC}"
-            echo -e "${DIM}  Example: spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s)${NC}"
-            echo ""
-            read -p "Thread schedule: " THREADS_SCHEDULE
-            HOLD_PERIOD=$(prompt_with_default "Hold period (seconds)" "600")
+            echo -e "${DIM}Available concurrency profiles in ${TEST_PROPS_DIR}/${NC}"
+            echo -e "${DIM}  (5 columns: Threads,StartTime,StartupTime,HoldTime,ShutdownTime)${NC}"
+            # Only 5-column CSVs suit this plan; a 3-column arrivals profile would
+            # be rejected by the injector, so do not offer it here.
+            LOAD_PROFILES=()
+            for c in $(ls -1 "$TEST_PROPS_DIR"/*.csv 2>/dev/null | sort); do
+                cols=$(grep -vE '^\s*$' "$c" | head -1 | awk -F, '{print NF}')
+                [ "${cols:-0}" -ge 5 ] && LOAD_PROFILES+=("$c")
+            done
+            if [ ${#LOAD_PROFILES[@]} -gt 0 ]; then
+                for i in "${!LOAD_PROFILES[@]}"; do
+                    echo "  $((i + 1))) $(basename "${LOAD_PROFILES[$i]}")"
+                done
+                echo ""
+                read -p "Select concurrency profile [1-${#LOAD_PROFILES[@]}]: " lp_choice
+                LOAD_PROFILE="${LOAD_PROFILES[$((lp_choice - 1))]}"
+            else
+                read -p "Concurrency profile CSV path: " LOAD_PROFILE
+            fi
             CONCURRENT_QUERY_COUNT="1"
             RAMP_UP_TIME="0"
             RAMP_UP_STEPS="1"
@@ -365,9 +378,6 @@ if [[ "$props_choice" =~ ^[Nn]$ ]]; then
         fi
         if [ -n "${LOAD_PROFILE:-}" ]; then
             echo "LOAD_PROFILE=${LOAD_PROFILE}"
-        fi
-        if [ -n "${THREADS_SCHEDULE:-}" ]; then
-            echo "threads_schedule=${THREADS_SCHEDULE}"
         fi
         if [ -n "${STOP_THREAD_ON_EOF:-}" ]; then
             echo "STOP_THREAD_ON_EOF=${STOP_THREAD_ON_EOF}"
@@ -539,7 +549,7 @@ if [ -n "$METADATA_FILE" ]; then
 fi
 
 # Read test properties without executing them (values like
-# threads_schedule=spawn(4,0s,...) are not valid bash)
+# values containing parentheses or spaces are not valid bash)
 while IFS='=' read -r key value; do
     [[ "$key" =~ ^[[:space:]]*# ]] && continue
     key=$(echo "$key" | xargs)
@@ -586,11 +596,18 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 REPORT_DIR="${REPORT_PATH:-reports}/${TIMESTAMP}"
 mkdir -p "$REPORT_DIR"
 
-# Apply the load profile CSV to the plan's arrivals schedule.
-# The plan's own JSR223 PreProcessor cannot do this: it runs when a sampler
-# fires, by which point the thread group has already read its Schedule. So the
-# schedule is injected here, before JMeter starts.
-if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+# Apply the load profile CSV to the plan's thread-group schedule.
+# Covers both families: FreeFormArrivalsThreadGroup (arrival rate) and
+# UltimateThreadGroup (concurrency waves).
+# The plans' own JSR223 PreProcessors cannot do this: they run when a sampler
+# fires, by which point the thread group has already read its schedule and
+# started threads. So the schedule is injected here, before JMeter starts.
+if grep -qE "FreeFormArrivalsThreadGroup|UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+    # The two families take different CSV formats, so the default follows the plan.
+    if [ -z "${LOAD_PROFILE:-}" ] && grep -q "UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null \
+       && [ -f "${PROJECT_ROOT}/test_properties/utg_load_profile.csv" ]; then
+        LOAD_PROFILE="test_properties/utg_load_profile.csv"
+    fi
     if [ -z "${LOAD_PROFILE:-}" ]; then
         echo -e "${YELLOW}Warning: load-profile plan selected but LOAD_PROFILE is not set.${NC}"
         echo -e "${YELLOW}The plan's built-in schedule will be used instead.${NC}"
@@ -609,7 +626,7 @@ if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null; then
 fi
 
 # Build JMeter command as an array so values containing spaces or shell
-# metacharacters (e.g. threads_schedule=spawn(4,0s,...)) reach JMeter intact
+# metacharacters (e.g. a query path with spaces) reach JMeter intact
 JMETER_CMD=("$JMETER_HOME/bin/jmeter" -n)
 JMETER_CMD+=(-t "$TEST_PLAN")
 JMETER_CMD+=(-q "$CONNECTION_FILE")
@@ -671,15 +688,26 @@ if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
     # Only compare against a load profile when the plan is actually profile-driven.
     # LOAD_PROFILE defaults to an existing file, so passing it unconditionally made
     # every non-profile run report a bogus "SHORTFALL" against a schedule it never used.
-    if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null \
+    if grep -qE "FreeFormArrivalsThreadGroup|UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null \
        && [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ]; then
         CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
     fi
     CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
     CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}" --meta "run_type=${PLAN_TYPE}")
     CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
-    python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}" || \
+    # Exit 2 from the report means the run itself failed (no samples, or an error
+    # rate above MAX_ERROR_PCT). Propagate it: a run where the queries did not
+    # succeed must not report success, or callers and CI treat it as a result.
+    RUN_FAILED=0
+    set +e
+    python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}"
+    CAPTURE_RC=$?
+    set -e
+    if [ "$CAPTURE_RC" -eq 2 ]; then
+        RUN_FAILED=1
+    elif [ "$CAPTURE_RC" -ne 0 ]; then
         echo -e "  ${YELLOW}run report capture failed (results are unaffected)${NC}"
+    fi
 fi
 
 # The plan stamps these with JMeter's own START_TIME, which differs from run_id by
@@ -697,9 +725,15 @@ done
     cp "${REPORT_DIR}/dashboard/statistics.json" "${REPORT_DIR}/statistics.json"
 
 echo ""
-echo -e "${GREEN}=========================================="
-echo " Test Complete!"
-echo -e "==========================================${NC}"
+if [ "${RUN_FAILED:-0}" -eq 1 ]; then
+    echo -e "${RED}=========================================="
+    echo " Test FAILED"
+    echo -e "==========================================${NC}"
+else
+    echo -e "${GREEN}=========================================="
+    echo " Test Complete!"
+    echo -e "==========================================${NC}"
+fi
 echo ""
 echo "  Results: ${REPORT_DIR}/"
 echo "  Report:  ${REPORT_DIR}/run_report.md"
@@ -733,3 +767,7 @@ if [ "${COPY_TO_S3:-false}" = "true" ] && [ -n "${S3_BASE_PATH:-}" ]; then
 fi
 
 echo ""
+
+# Exit non-zero when the run produced no usable result, so callers and CI can
+# tell a real benchmark from one where every query failed.
+exit "${RUN_FAILED:-0}"

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -466,6 +466,16 @@ if [ -n "$METADATA_FILE" ]; then
     source "$METADATA_FILE"
 fi
 
+# Values set in the environment win over the properties file, so a single
+# properties file can be reused across runs:
+#   LOAD_PROFILE=test_properties/spike.csv ./run_jmeter_tests_interactive.sh
+# Matches the precedence run_test.sh already implements.
+OVERRIDABLE="LOAD_PROFILE HOLD_PERIOD MAX_CONCURRANCY COPY_TO_S3 RECYCLE_ON_EOF \
+RANDOM_ORDER QPS QPM CONCURRENT_QUERY_COUNT RAMP_UP_TIME RAMP_UP_STEPS QUERY_TIMEOUT"
+for _k in $OVERRIDABLE; do
+    [ -n "${!_k:-}" ] && printf -v "_ENV_$_k" '%s' "${!_k}"
+done
+
 # Read test properties without executing them (values like
 # threads_schedule=spawn(4,0s,...) are not valid bash)
 while IFS='=' read -r key value; do
@@ -474,6 +484,15 @@ while IFS='=' read -r key value; do
     [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     printf -v "$key" '%s' "$value"
 done < "$TEST_PROPERTIES"
+
+# Re-apply the environment overrides captured above
+for _k in $OVERRIDABLE; do
+    _saved="_ENV_$_k"
+    if [ -n "${!_saved:-}" ]; then
+        printf -v "$_k" '%s' "${!_saved}"
+        echo -e "  ${DIM}override: ${_k}=${!_saved}${NC}"
+    fi
+done
 
 # Determine JMETER_HOME
 if [ -z "$JMETER_HOME" ]; then

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -601,6 +601,12 @@ done < "$TEST_PROPERTIES"
 # Override QUERY_PATH with user selection
 JMETER_CMD+=("-JQUERY_PATH=$QUERY_FILE")
 
+# The test plans write AggregateReport_<START_TIME>.csv and SummaryReport_... to
+# ${REPORT_PATH}. Point that at this run's directory, otherwise they land in the
+# reports/ root, are stamped with JMeter's own START_TIME (which differs from the
+# run_id by a few seconds), and never reach S3. Last -J wins over the file value.
+JMETER_CMD+=("-JREPORT_PATH=$REPORT_DIR")
+
 echo -e "${BLUE}Running JMeter...${NC}"
 echo -e "${DIM}${JMETER_CMD[*]}${NC}"
 echo ""
@@ -620,6 +626,15 @@ if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
     python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}" || \
         echo -e "  ${YELLOW}run report capture failed (results are unaffected)${NC}"
 fi
+
+# The plan stamps these with JMeter's own START_TIME, which differs from run_id by
+# a few seconds. Normalise to the names the analysis and Athena scripts expect.
+for _f in "${REPORT_DIR}"/AggregateReport_*.csv; do
+    [ -e "$_f" ] && mv -f "$_f" "${REPORT_DIR}/AggregateReport.csv" && break
+done
+for _f in "${REPORT_DIR}"/SummaryReport_*.csv; do
+    [ -e "$_f" ] && mv -f "$_f" "${REPORT_DIR}/SummaryReport.csv" && break
+done
 
 # JMeter writes statistics.json under dashboard/; downstream analysis and Athena
 # scripts look for it at the run root, so publish a copy there.

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -608,12 +608,31 @@ echo ""
 # Run JMeter
 "${JMETER_CMD[@]}"
 
+# Capture a standard run report alongside the raw results, so every run is
+# self-describing and the analysis does not depend on anyone remembering to run
+# it. Writes run_summary.json + run_report.md into the run directory.
+if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
+    CAPTURE_ARGS=("$REPORT_DIR")
+    [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ] && CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
+    CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
+    CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}" --meta "run_type=${PLAN_TYPE}")
+    CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
+    python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}" || \
+        echo -e "  ${YELLOW}run report capture failed (results are unaffected)${NC}"
+fi
+
+# JMeter writes statistics.json under dashboard/; downstream analysis and Athena
+# scripts look for it at the run root, so publish a copy there.
+[ -f "${REPORT_DIR}/dashboard/statistics.json" ] && \
+    cp "${REPORT_DIR}/dashboard/statistics.json" "${REPORT_DIR}/statistics.json"
+
 echo ""
 echo -e "${GREEN}=========================================="
 echo " Test Complete!"
 echo -e "==========================================${NC}"
 echo ""
 echo "  Results: ${REPORT_DIR}/"
+echo "  Report:  ${REPORT_DIR}/run_report.md"
 echo "  Dashboard: ${REPORT_DIR}/dashboard/index.html"
 echo ""
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -512,7 +512,7 @@ echo ""
 # Source metadata if present (to get COPY_TO_S3 override, ENGINE, etc.)
 if [ -n "$METADATA_FILE" ]; then
     echo -e "${DIM}Metadata overrides:${NC}"
-    grep -E "^(ENGINE|COPY_TO_S3|S3_BASE_PATH|BENCHMARK_TYPE)=" "$METADATA_FILE" 2>/dev/null | while read -r line; do
+    grep -E "^(ENGINE|COPY_TO_S3|S3_REPORT_PATH|S3_BASE_PATH|BENCHMARK_TYPE|RUN_TYPE)=" "$METADATA_FILE" 2>/dev/null | while read -r line; do
         echo "  $line"
     done
     echo ""
@@ -538,7 +538,7 @@ echo ""
 # Captured BEFORE the metadata is sourced: metadata defines COPY_TO_S3 and
 # would otherwise overwrite the environment value before it could be saved.
 OVERRIDABLE="LOAD_PROFILE GENERATE_DASHBOARD HOLD_PERIOD MAX_CONCURRANCY COPY_TO_S3 RECYCLE_ON_EOF \
-RANDOM_ORDER QPS QPM CONCURRENT_QUERY_COUNT RAMP_UP_TIME RAMP_UP_STEPS QUERY_TIMEOUT"
+RANDOM_ORDER QPS QPM CONCURRENT_QUERY_COUNT RAMP_UP_TIME RAMP_UP_STEPS QUERY_TIMEOUT MAX_ERROR_PCT RUN_TYPE S3_REPORT_PATH"
 for _k in $OVERRIDABLE; do
     [ -n "${!_k:-}" ] && printf -v "_ENV_$_k" '%s' "${!_k}"
 done
@@ -547,6 +547,12 @@ done
 if [ -n "$METADATA_FILE" ]; then
     source "$METADATA_FILE"
 fi
+
+if [ -n "${S3_BASE_PATH:-}" ] && [ -n "${S3_REPORT_PATH:-}" ] \
+   && [ "$S3_BASE_PATH" != "$S3_REPORT_PATH" ]; then
+    echo -e "${YELLOW}Warning: S3_BASE_PATH overrides S3_REPORT_PATH; migrate metadata to S3_REPORT_PATH.${NC}"
+fi
+S3_UPLOAD_ROOT="${S3_BASE_PATH:-${S3_REPORT_PATH:-}}"
 
 # Read test properties without executing them (values like
 # values containing parentheses or spaces are not valid bash)
@@ -592,9 +598,14 @@ echo -e "${GREEN}Using JMeter: ${JMETER_HOME}${NC}"
 echo ""
 
 # Generate report directory with timestamp
-TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TIMESTAMP=$(python3 -c 'from datetime import datetime; print(datetime.now().strftime("%Y%m%d-%H%M%S-%f"))')
 REPORT_DIR="${REPORT_PATH:-reports}/${TIMESTAMP}"
-mkdir -p "$REPORT_DIR"
+mkdir -p "${REPORT_PATH:-reports}"
+if ! mkdir "$REPORT_DIR"; then
+    echo -e "${RED}Error: report directory already exists: ${REPORT_DIR}${NC}"
+    exit 1
+fi
+ORIGINAL_TEST_PLAN="$TEST_PLAN"
 
 # Apply the load profile CSV to the plan's thread-group schedule.
 # Covers both families: FreeFormArrivalsThreadGroup (arrival rate) and
@@ -677,8 +688,30 @@ echo -e "${BLUE}Running JMeter...${NC}"
 echo -e "${DIM}${JMETER_CMD[*]}${NC}"
 echo ""
 
-# Run JMeter
+# Run JMeter, but always finalize whatever artifacts it produced.
+set +e
 "${JMETER_CMD[@]}"
+JMETER_RC=$?
+set -e
+RUN_FAILED=0
+if [ "$JMETER_RC" -ne 0 ]; then
+    RUN_FAILED=1
+    echo -e "${RED}JMeter exited with status ${JMETER_RC}; finalizing available artifacts.${NC}"
+fi
+
+INFERRED_RUN_TYPE=""
+case "$PLAN_TYPE" in
+    run_once)
+        if [ "${CONCURRENT_QUERY_COUNT:-1}" = "1" ]; then INFERRED_RUN_TYPE="sequential";
+        else INFERRED_RUN_TYPE="concurrency_${CONCURRENT_QUERY_COUNT}"; fi ;;
+    concurrency) INFERRED_RUN_TYPE="concurrency_${CONCURRENT_QUERY_COUNT:-1}" ;;
+    qps) INFERRED_RUN_TYPE="qps_${QPS:-1}" ;;
+    qpm) INFERRED_RUN_TYPE="qpm_${QPM:-1}" ;;
+    qps_loadprofile) INFERRED_RUN_TYPE="qps_load_profile" ;;
+    variable_concurrency) INFERRED_RUN_TYPE="variable_concurrency" ;;
+    *) INFERRED_RUN_TYPE="custom" ;;
+esac
+RUN_TYPE=$(printf '%s' "${RUN_TYPE:-$INFERRED_RUN_TYPE}" | tr -cs 'A-Za-z0-9._-' '_')
 
 # Capture a standard run report alongside the raw results, so every run is
 # self-describing and the analysis does not depend on anyone remembering to run
@@ -693,12 +726,23 @@ if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
         CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
     fi
     CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
-    CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}" --meta "run_type=${PLAN_TYPE}")
-    CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
+    CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}" --meta "run_type=${RUN_TYPE}")
+    CAPTURE_ARGS+=(--meta "test_plan=$(basename "$ORIGINAL_TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
+    [ -n "${GENERATED_PLAN:-}" ] && CAPTURE_ARGS+=(--meta "generated_plan=$(basename "$GENERATED_PLAN")")
+    QUERY_SHA=$(python3 "${PROJECT_ROOT}/utilities/query_file_info.py" "$QUERY_FILE" --field sha256)
+    CAPTURE_ARGS+=(--meta "query_sha256=${QUERY_SHA}" --meta "requested_concurrency=${CONCURRENT_QUERY_COUNT:-unknown}")
+    CAPTURE_ARGS+=(--meta "requested_qps=${QPS:-unknown}" --meta "requested_qpm=${QPM:-unknown}")
+    CAPTURE_ARGS+=(--meta "hold_period=${HOLD_PERIOD:-unknown}" --meta "ramp_up_time=${RAMP_UP_TIME:-unknown}" --meta "ramp_up_steps=${RAMP_UP_STEPS:-unknown}")
+    CAPTURE_ARGS+=(--meta "max_concurrency=${MAX_CONCURRANCY:-unknown}" --meta "recycle_on_eof=${RECYCLE_ON_EOF:-unknown}" --meta "random_order=${RANDOM_ORDER:-unknown}")
+    CAPTURE_ARGS+=(--meta "jmeter_version=$(basename "$JMETER_HOME")" --meta "java_version=$(java -version 2>&1 | head -1)")
+    CAPTURE_ARGS+=(--meta "git_commit=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)")
+    if [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ] \
+       && grep -qE "FreeFormArrivalsThreadGroup|UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+        CAPTURE_ARGS+=(--meta "profile=$(basename "$LOAD_PROFILE")" --meta "profile_sha256=$(python3 "${PROJECT_ROOT}/utilities/query_file_info.py" "$LOAD_PROFILE" --field sha256)")
+    fi
     # Exit 2 from the report means the run itself failed (no samples, or an error
     # rate above MAX_ERROR_PCT). Propagate it: a run where the queries did not
     # succeed must not report success, or callers and CI treat it as a result.
-    RUN_FAILED=0
     set +e
     python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}"
     CAPTURE_RC=$?
@@ -737,18 +781,22 @@ fi
 echo ""
 echo "  Results: ${REPORT_DIR}/"
 echo "  Report:  ${REPORT_DIR}/run_report.md"
-echo "  Dashboard: ${REPORT_DIR}/dashboard/index.html"
+if [ "${GENERATE_DASHBOARD:-true}" != "false" ]; then
+    echo "  Dashboard: ${REPORT_DIR}/dashboard/index.html"
+else
+    echo "  Dashboard: disabled"
+fi
 echo ""
 
 # Copy to S3 if enabled
-if [ "${COPY_TO_S3:-false}" = "true" ] && [ -n "${S3_BASE_PATH:-}" ]; then
+if [ "${COPY_TO_S3:-false}" = "true" ] && [ -n "${S3_UPLOAD_ROOT:-}" ]; then
     echo "Uploading results to S3..."
     # Build S3 path from metadata
     ENGINE_VAL="${ENGINE:-unknown}"
     CLUSTER_SIZE_VAL="${CLUSTER_SIZE:-unknown}"
     BENCHMARK_VAL="${BENCHMARK_TYPE:-unknown}"
-    RUN_TYPE_VAL="run_type=${PLAN_TYPE}"
-    S3_DEST="${S3_BASE_PATH}/engine=${ENGINE_VAL}/cluster_size=${CLUSTER_SIZE_VAL}/benchmark=${BENCHMARK_VAL}/${RUN_TYPE_VAL}/run_id=${TIMESTAMP}/"
+    RUN_TYPE_VAL="run_type=${RUN_TYPE}"
+    S3_DEST="${S3_UPLOAD_ROOT%/}/engine=${ENGINE_VAL}/cluster_size=${CLUSTER_SIZE_VAL}/benchmark=${BENCHMARK_VAL}/${RUN_TYPE_VAL}/run_id=${TIMESTAMP}/"
 
     echo "  S3 path: ${S3_DEST}"
     # The JMeter HTML dashboard vendors jQuery/Bootstrap/font-awesome/flot -

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -646,6 +646,16 @@ JMETER_CMD+=("-JQUERY_PATH=$QUERY_FILE")
 # run_id by a few seconds), and never reach S3. Last -J wins over the file value.
 JMETER_CMD+=("-JREPORT_PATH=$REPORT_DIR")
 
+# The QPM plan uses Unit=M on its thread group, which governs BOTH the arrival rate
+# (QPM = per minute) and the hold duration - so HOLD_PERIOD is MINUTES there, unlike
+# every other plan where it is seconds. The two cannot be separated: setting Unit=S
+# would make QPM mean per-second. Warn rather than silently run 60x too long.
+if grep -q '<stringProp name="Unit">M</stringProp>' "$TEST_PLAN" 2>/dev/null; then
+    echo -e "${YELLOW}  Note: this plan measures time in MINUTES.${NC}"
+    echo -e "${YELLOW}  HOLD_PERIOD=${HOLD_PERIOD:-?} means ${HOLD_PERIOD:-?} minute(s), not seconds.${NC}"
+    echo ""
+fi
+
 echo -e "${BLUE}Running JMeter...${NC}"
 echo -e "${DIM}${JMETER_CMD[*]}${NC}"
 echo ""
@@ -658,7 +668,13 @@ echo ""
 # it. Writes run_summary.json + run_report.md into the run directory.
 if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
     CAPTURE_ARGS=("$REPORT_DIR")
-    [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ] && CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
+    # Only compare against a load profile when the plan is actually profile-driven.
+    # LOAD_PROFILE defaults to an existing file, so passing it unconditionally made
+    # every non-profile run report a bogus "SHORTFALL" against a schedule it never used.
+    if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null \
+       && [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ]; then
+        CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
+    fi
     CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
     CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}" --meta "run_type=${PLAN_TYPE}")
     CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_jmeter_tests_interactive.sh
@@ -505,6 +505,28 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 REPORT_DIR="${REPORT_PATH:-reports}/${TIMESTAMP}"
 mkdir -p "$REPORT_DIR"
 
+# Apply the load profile CSV to the plan's arrivals schedule.
+# The plan's own JSR223 PreProcessor cannot do this: it runs when a sampler
+# fires, by which point the thread group has already read its Schedule. So the
+# schedule is injected here, before JMeter starts.
+if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+    if [ -z "${LOAD_PROFILE:-}" ]; then
+        echo -e "${YELLOW}Warning: load-profile plan selected but LOAD_PROFILE is not set.${NC}"
+        echo -e "${YELLOW}The plan's built-in schedule will be used instead.${NC}"
+        echo ""
+    elif [ ! -f "$LOAD_PROFILE" ]; then
+        echo -e "${RED}Error: LOAD_PROFILE file not found: ${LOAD_PROFILE}${NC}"
+        exit 1
+    else
+        GENERATED_PLAN="${REPORT_DIR}/$(basename "${TEST_PLAN%.jmx}")-generated.jmx"
+        python3 "${PROJECT_ROOT}/utilities/apply_load_profile.py" \
+            "$TEST_PLAN" "$LOAD_PROFILE" "$GENERATED_PLAN" || exit 1
+        echo -e "  ${DIM}profile: ${LOAD_PROFILE}${NC}"
+        echo ""
+        TEST_PLAN="$GENERATED_PLAN"
+    fi
+fi
+
 # Build JMeter command as an array so values containing spaces or shell
 # metacharacters (e.g. threads_schedule=spawn(4,0s,...)) reach JMeter intact
 JMETER_CMD=("$JMETER_HOME/bin/jmeter" -n)

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -373,6 +373,16 @@ fi
 
 echo -e "${DIM}${JMETER_CMD[*]}${NC}"
 echo ""
+# The QPM plan uses Unit=M on its thread group, which governs BOTH the arrival rate
+# (QPM = per minute) and the hold duration - so HOLD_PERIOD is MINUTES there, unlike
+# every other plan where it is seconds. The two cannot be separated: setting Unit=S
+# would make QPM mean per-second. Warn rather than silently run 60x too long.
+if grep -q '<stringProp name="Unit">M</stringProp>' "$TEST_PLAN" 2>/dev/null; then
+    echo -e "${YELLOW}  Note: this plan measures time in MINUTES.${NC}"
+    echo -e "${YELLOW}  HOLD_PERIOD=${HOLD_PERIOD:-?} means ${HOLD_PERIOD:-?} minute(s), not seconds.${NC}"
+    echo ""
+fi
+
 echo -e "${BLUE}Running JMeter...${NC}"
 echo ""
 
@@ -384,7 +394,13 @@ echo ""
 # it. Writes run_summary.json + run_report.md into the run directory.
 if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
     CAPTURE_ARGS=("$REPORT_DIR")
-    [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ] && CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
+    # Only compare against a load profile when the plan is actually profile-driven.
+    # LOAD_PROFILE defaults to an existing file, so passing it unconditionally made
+    # every non-profile run report a bogus "SHORTFALL" against a schedule it never used.
+    if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null \
+       && [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ]; then
+        CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
+    fi
     CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
     CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}")
     CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -390,7 +390,18 @@ if [ "${COPY_TO_S3}" = "true" ] && [ -n "${S3_BASE_PATH:-}" ]; then
     echo ""
     echo "Uploading results to S3..."
     echo "  ${S3_DEST}"
-    aws s3 cp "${REPORT_DIR}/" "${S3_DEST}" --recursive
+    # The JMeter HTML dashboard vendors jQuery/Bootstrap/font-awesome/flot -
+    # ~120 files and ~3.5MB per run, byte-identical every time and read by
+    # nothing downstream. Upload the data and the dashboard pages, skip the
+    # vendored assets. Set S3_UPLOAD_DASHBOARD_ASSETS=true to include them.
+    if [ "${S3_UPLOAD_DASHBOARD_ASSETS:-false}" = "true" ]; then
+        aws s3 cp "${REPORT_DIR}/" "${S3_DEST}" --recursive
+    else
+        aws s3 cp "${REPORT_DIR}/" "${S3_DEST}" --recursive \
+            --exclude "dashboard/sbadmin2-1.0.7/*" \
+            --exclude "dashboard/content/css/*" \
+            --exclude "dashboard/content/js/*"
+    fi
     echo -e "  ${GREEN}Uploaded to S3${NC}"
 fi
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -372,12 +372,31 @@ echo ""
 # Run JMeter
 "${JMETER_CMD[@]}"
 
+# Capture a standard run report alongside the raw results, so every run is
+# self-describing and the analysis does not depend on anyone remembering to run
+# it. Writes run_summary.json + run_report.md into the run directory.
+if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
+    CAPTURE_ARGS=("$REPORT_DIR")
+    [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ] && CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
+    CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
+    CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}")
+    CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
+    python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}" || \
+        echo -e "  ${YELLOW}run report capture failed (results are unaffected)${NC}"
+fi
+
+# JMeter writes statistics.json under dashboard/; downstream analysis and Athena
+# scripts look for it at the run root, so publish a copy there.
+[ -f "${REPORT_DIR}/dashboard/statistics.json" ] && \
+    cp "${REPORT_DIR}/dashboard/statistics.json" "${REPORT_DIR}/statistics.json"
+
 echo ""
 echo -e "${GREEN}=========================================="
 echo " Test Complete!"
 echo -e "==========================================${NC}"
 echo ""
 echo "  Results:   ${REPORT_DIR}/"
+echo "  Report:    ${REPORT_DIR}/run_report.md"
 echo "  Dashboard: ${REPORT_DIR}/dashboard/index.html"
 
 # Copy to S3 if enabled

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -343,7 +343,10 @@ JMETER_CMD+=(-e -o "${REPORT_DIR}/dashboard")
 
 # Pass all test parameters as JMeter -J properties
 JMETER_CMD+=("-JQUERY_PATH=$QUERY_FILE")
-JMETER_CMD+=("-JREPORT_PATH=$REPORT_PATH")
+# Point REPORT_PATH at this run's directory so the plan's
+# AggregateReport_<START_TIME>.csv / SummaryReport_... land with the run
+# instead of the reports/ root (where they are orphaned and never uploaded).
+JMETER_CMD+=("-JREPORT_PATH=$REPORT_DIR")
 JMETER_CMD+=("-JCOPY_TO_S3=$COPY_TO_S3")
 JMETER_CMD+=("-JS3_REPORT_PATH=$S3_REPORT_PATH")
 JMETER_CMD+=("-JCONCURRENT_QUERY_COUNT=$CONCURRENT_QUERY_COUNT")
@@ -384,6 +387,15 @@ if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
     python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}" || \
         echo -e "  ${YELLOW}run report capture failed (results are unaffected)${NC}"
 fi
+
+# The plan stamps these with JMeter's own START_TIME, which differs from run_id by
+# a few seconds. Normalise to the names the analysis and Athena scripts expect.
+for _f in "${REPORT_DIR}"/AggregateReport_*.csv; do
+    [ -e "$_f" ] && mv -f "$_f" "${REPORT_DIR}/AggregateReport.csv" && break
+done
+for _f in "${REPORT_DIR}"/SummaryReport_*.csv; do
+    [ -e "$_f" ] && mv -f "$_f" "${REPORT_DIR}/SummaryReport.csv" && break
+done
 
 # JMeter writes statistics.json under dashboard/; downstream analysis and Athena
 # scripts look for it at the run root, so publish a copy there.

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -312,6 +312,27 @@ echo ""
 # Build and run JMeter command
 # ============================================================================
 
+# Apply the load profile CSV to the plan's arrivals schedule.
+# The plan's own JSR223 PreProcessor cannot do this: it runs when a sampler
+# fires, by which point the thread group has already read its Schedule. So the
+# schedule is injected here, before JMeter starts.
+if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+    if [ -z "${LOAD_PROFILE:-}" ]; then
+        echo -e "${YELLOW}Warning: load-profile plan selected but LOAD_PROFILE is not set.${NC}"
+        echo -e "${YELLOW}The plan's built-in schedule will be used instead.${NC}"
+        echo ""
+    elif [ ! -f "$LOAD_PROFILE" ]; then
+        echo -e "${RED}Error: LOAD_PROFILE file not found: ${LOAD_PROFILE}${NC}"
+        exit 1
+    else
+        GENERATED_PLAN="${REPORT_DIR}/$(basename "${TEST_PLAN%.jmx}")-generated.jmx"
+        python3 "${PROJECT_ROOT}/utilities/apply_load_profile.py" \
+            "$TEST_PLAN" "$LOAD_PROFILE" "$GENERATED_PLAN" || exit 1
+        echo ""
+        TEST_PLAN="$GENERATED_PLAN"
+    fi
+fi
+
 # Built as an array so values containing spaces or shell metacharacters
 # (e.g. threads_schedule=spawn(4,0s,...)) reach JMeter intact
 JMETER_CMD=("$JMETER_HOME/bin/jmeter" -n)

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -29,6 +29,13 @@
 #   LIMIT_RESULTSET           - max result rows (default: 1000)
 #   MAX_CONCURRANCY           - max threads (default: 900)
 #   JMETER_HOME               - JMeter installation path (auto-detected if not set)
+#   MAX_ERROR_PCT             - fail the run above this error rate (default: 5)
+#
+# Exit codes:
+#   0  the run completed and the error rate was within MAX_ERROR_PCT
+#   1  the run is not a usable result - no samples recorded, or too many errors.
+#      The results directory is still written so the failure can be diagnosed.
+#      Set MAX_ERROR_PCT=100 to accept any error rate.
 #
 # Examples:
 #
@@ -95,7 +102,6 @@ if [ -n "$1" ]; then
     _SAVE_LIMIT_RESULTSET="${LIMIT_RESULTSET:-}"
     _SAVE_MAX_CONCURRANCY="${MAX_CONCURRANCY:-}"
     _SAVE_JMETER_HOME="${JMETER_HOME:-}"
-    _SAVE_THREADS_SCHEDULE="${THREADS_SCHEDULE:-}"
 
     source "$SUITE_FILE"
 
@@ -120,7 +126,6 @@ if [ -n "$1" ]; then
     [ -n "$_SAVE_LIMIT_RESULTSET" ] && LIMIT_RESULTSET="$_SAVE_LIMIT_RESULTSET"
     [ -n "$_SAVE_MAX_CONCURRANCY" ] && MAX_CONCURRANCY="$_SAVE_MAX_CONCURRANCY"
     [ -n "$_SAVE_JMETER_HOME" ] && JMETER_HOME="$_SAVE_JMETER_HOME"
-    [ -n "$_SAVE_THREADS_SCHEDULE" ] && THREADS_SCHEDULE="$_SAVE_THREADS_SCHEDULE"
 fi
 
 # ============================================================================
@@ -182,7 +187,14 @@ QPM="${QPM:-10}"
 HOLD_PERIOD="${HOLD_PERIOD:-300}"
 RAMP_UP_TIME="${RAMP_UP_TIME:-1}"
 RAMP_UP_STEPS="${RAMP_UP_STEPS:-1}"
-LOAD_PROFILE="${LOAD_PROFILE:-test_properties/load_profile.csv}"
+# The two load-profile plan families take different CSV formats, so the default
+# follows the plan: 5-column concurrency waves for UltimateThreadGroup,
+# 3-column arrival-rate steps for FreeFormArrivalsThreadGroup.
+if grep -q "UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+    LOAD_PROFILE="${LOAD_PROFILE:-test_properties/utg_load_profile.csv}"
+else
+    LOAD_PROFILE="${LOAD_PROFILE:-test_properties/load_profile.csv}"
+fi
 RANDOM_ORDER="${RANDOM_ORDER:-false}"
 RECYCLE_ON_EOF="${RECYCLE_ON_EOF:-false}"
 COPY_TO_S3="${COPY_TO_S3:-false}"
@@ -312,11 +324,13 @@ echo ""
 # Build and run JMeter command
 # ============================================================================
 
-# Apply the load profile CSV to the plan's arrivals schedule.
-# The plan's own JSR223 PreProcessor cannot do this: it runs when a sampler
-# fires, by which point the thread group has already read its Schedule. So the
-# schedule is injected here, before JMeter starts.
-if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+# Apply the load profile CSV to the plan's thread-group schedule.
+# Covers both families: FreeFormArrivalsThreadGroup (arrival rate) and
+# UltimateThreadGroup (concurrency waves).
+# The plans' own JSR223 PreProcessors cannot do this: they run when a sampler
+# fires, by which point the thread group has already read its schedule and
+# started threads. So the schedule is injected here, before JMeter starts.
+if grep -qE "FreeFormArrivalsThreadGroup|UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null; then
     if [ -z "${LOAD_PROFILE:-}" ]; then
         echo -e "${YELLOW}Warning: load-profile plan selected but LOAD_PROFILE is not set.${NC}"
         echo -e "${YELLOW}The plan's built-in schedule will be used instead.${NC}"
@@ -334,7 +348,8 @@ if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null; then
 fi
 
 # Built as an array so values containing spaces or shell metacharacters
-# (e.g. threads_schedule=spawn(4,0s,...)) reach JMeter intact
+# (e.g. a query path with spaces, or a value containing parentheses) reach
+# JMeter intact rather than being re-split by the shell
 JMETER_CMD=("$JMETER_HOME/bin/jmeter" -n)
 JMETER_CMD+=(-t "$TEST_PLAN")
 JMETER_CMD+=(-q "$CONNECTION_FILE")
@@ -366,11 +381,6 @@ JMETER_CMD+=("-JQUERY_TIMEOUT=$QUERY_TIMEOUT")
 JMETER_CMD+=("-JLIMIT_RESULTSET=$LIMIT_RESULTSET")
 JMETER_CMD+=("-JMAX_CONCURRANCY=$MAX_CONCURRANCY")
 
-# Optional: threads_schedule for variable concurrency
-if [ -n "${THREADS_SCHEDULE:-}" ]; then
-    JMETER_CMD+=("-Jthreads_schedule=$THREADS_SCHEDULE")
-fi
-
 echo -e "${DIM}${JMETER_CMD[*]}${NC}"
 echo ""
 # The QPM plan uses Unit=M on its thread group, which governs BOTH the arrival rate
@@ -397,15 +407,26 @@ if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
     # Only compare against a load profile when the plan is actually profile-driven.
     # LOAD_PROFILE defaults to an existing file, so passing it unconditionally made
     # every non-profile run report a bogus "SHORTFALL" against a schedule it never used.
-    if grep -q "FreeFormArrivalsThreadGroup" "$TEST_PLAN" 2>/dev/null \
+    if grep -qE "FreeFormArrivalsThreadGroup|UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null \
        && [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ]; then
         CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
     fi
     CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
     CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}")
     CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
-    python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}" || \
+    # Exit 2 from the report means the run itself failed (no samples, or an error
+    # rate above MAX_ERROR_PCT). Propagate it: a run where the queries did not
+    # succeed must not report success, or callers and CI treat it as a result.
+    RUN_FAILED=0
+    set +e
+    python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}"
+    CAPTURE_RC=$?
+    set -e
+    if [ "$CAPTURE_RC" -eq 2 ]; then
+        RUN_FAILED=1
+    elif [ "$CAPTURE_RC" -ne 0 ]; then
         echo -e "  ${YELLOW}run report capture failed (results are unaffected)${NC}"
+    fi
 fi
 
 # The plan stamps these with JMeter's own START_TIME, which differs from run_id by
@@ -423,9 +444,15 @@ done
     cp "${REPORT_DIR}/dashboard/statistics.json" "${REPORT_DIR}/statistics.json"
 
 echo ""
-echo -e "${GREEN}=========================================="
-echo " Test Complete!"
-echo -e "==========================================${NC}"
+if [ "${RUN_FAILED:-0}" -eq 1 ]; then
+    echo -e "${RED}=========================================="
+    echo " Test FAILED"
+    echo -e "==========================================${NC}"
+else
+    echo -e "${GREEN}=========================================="
+    echo " Test Complete!"
+    echo -e "==========================================${NC}"
+fi
 echo ""
 echo "  Results:   ${REPORT_DIR}/"
 echo "  Report:    ${REPORT_DIR}/run_report.md"
@@ -457,3 +484,6 @@ if [ "${COPY_TO_S3}" = "true" ] && [ -n "${S3_BASE_PATH:-}" ]; then
 fi
 
 echo ""
+# Exit non-zero when the run produced no usable result, so callers and CI can
+# tell a real benchmark from one where every query failed.
+exit "${RUN_FAILED:-0}"

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -30,6 +30,7 @@
 #   MAX_CONCURRANCY           - max threads (default: 900)
 #   JMETER_HOME               - JMeter installation path (auto-detected if not set)
 #   MAX_ERROR_PCT             - fail the run above this error rate (default: 5)
+#   RUN_TYPE                  - S3 partition label (inferred from the plan if omitted)
 #
 # Exit codes:
 #   0  the run completed and the error rate was within MAX_ERROR_PCT
@@ -102,6 +103,9 @@ if [ -n "$1" ]; then
     _SAVE_LIMIT_RESULTSET="${LIMIT_RESULTSET:-}"
     _SAVE_MAX_CONCURRANCY="${MAX_CONCURRANCY:-}"
     _SAVE_JMETER_HOME="${JMETER_HOME:-}"
+    _SAVE_MAX_ERROR_PCT="${MAX_ERROR_PCT:-}"
+    _SAVE_GENERATE_DASHBOARD="${GENERATE_DASHBOARD:-}"
+    _SAVE_RUN_TYPE="${RUN_TYPE:-}"
 
     source "$SUITE_FILE"
 
@@ -126,6 +130,9 @@ if [ -n "$1" ]; then
     [ -n "$_SAVE_LIMIT_RESULTSET" ] && LIMIT_RESULTSET="$_SAVE_LIMIT_RESULTSET"
     [ -n "$_SAVE_MAX_CONCURRANCY" ] && MAX_CONCURRANCY="$_SAVE_MAX_CONCURRANCY"
     [ -n "$_SAVE_JMETER_HOME" ] && JMETER_HOME="$_SAVE_JMETER_HOME"
+    [ -n "$_SAVE_MAX_ERROR_PCT" ] && MAX_ERROR_PCT="$_SAVE_MAX_ERROR_PCT"
+    [ -n "$_SAVE_GENERATE_DASHBOARD" ] && GENERATE_DASHBOARD="$_SAVE_GENERATE_DASHBOARD"
+    [ -n "$_SAVE_RUN_TYPE" ] && RUN_TYPE="$_SAVE_RUN_TYPE"
 fi
 
 # ============================================================================
@@ -172,6 +179,8 @@ for var in CONNECTION_FILE TEST_PLAN QUERY_FILE; do
     fi
 done
 
+ORIGINAL_TEST_PLAN="$TEST_PLAN"
+
 if [ -n "${METADATA_FILE:-}" ] && [ ! -f "$METADATA_FILE" ]; then
     echo -e "${RED}Error: METADATA_FILE not found: ${METADATA_FILE}${NC}"
     exit 1
@@ -209,6 +218,15 @@ if [ -n "${METADATA_FILE:-}" ]; then
     source "$METADATA_FILE"
 fi
 
+# S3_REPORT_PATH is the public runner setting. Older metadata files use
+# S3_BASE_PATH; keep that as a backwards-compatible alias while ensuring the
+# documented setting is sufficient on its own.
+if [ -n "${S3_BASE_PATH:-}" ] && [ -n "${S3_REPORT_PATH:-}" ] \
+   && [ "$S3_BASE_PATH" != "$S3_REPORT_PATH" ]; then
+    echo -e "${YELLOW}Warning: S3_BASE_PATH overrides S3_REPORT_PATH; migrate metadata to S3_REPORT_PATH.${NC}"
+fi
+S3_UPLOAD_ROOT="${S3_BASE_PATH:-$S3_REPORT_PATH}"
+
 # ============================================================================
 # Find JMeter
 # ============================================================================
@@ -235,12 +253,16 @@ fi
 # Display configuration
 # ============================================================================
 
-TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TIMESTAMP=$(python3 -c 'from datetime import datetime; print(datetime.now().strftime("%Y%m%d-%H%M%S-%f"))')
 REPORT_DIR="${REPORT_PATH}/${TIMESTAMP}"
-mkdir -p "$REPORT_DIR"
+mkdir -p "$REPORT_PATH"
+if ! mkdir "$REPORT_DIR"; then
+    echo -e "${RED}Error: report directory already exists: ${REPORT_DIR}${NC}"
+    exit 1
+fi
 
-# Count queries in data file
-QUERY_COUNT=$(wc -l < "$QUERY_FILE" | tr -d ' ')
+# Count logical query rows, excluding a recognized CSV header.
+QUERY_COUNT=$(python3 "${PROJECT_ROOT}/utilities/query_file_info.py" "$QUERY_FILE" --field rows)
 
 # Infer test type from test plan filename for display
 PLAN_BASENAME=$(basename "$TEST_PLAN" .jmx | tr '[:upper:]' '[:lower:]')
@@ -260,6 +282,28 @@ else
     TEST_TYPE="Static Concurrency"
 fi
 
+# Keep uploads compatible with the partition layout consumed by the S3 and
+# Athena utilities. Callers can set RUN_TYPE explicitly for custom plans.
+if [ -z "${RUN_TYPE:-}" ]; then
+    case "$TEST_TYPE" in
+        "Run Once")
+            if [ "$CONCURRENT_QUERY_COUNT" = "1" ]; then
+                RUN_TYPE="sequential"
+            else
+                RUN_TYPE="concurrency_${CONCURRENT_QUERY_COUNT}"
+            fi
+            ;;
+        "Static Concurrency") RUN_TYPE="concurrency_${CONCURRENT_QUERY_COUNT}" ;;
+        "Constant QPS") RUN_TYPE="qps_${QPS}" ;;
+        "Constant QPM") RUN_TYPE="qpm_${QPM}" ;;
+        "Variable Concurrency (load profile)") RUN_TYPE="variable_concurrency" ;;
+        "QPS with Load Profile") RUN_TYPE="qps_load_profile" ;;
+        *) RUN_TYPE="custom" ;;
+    esac
+fi
+# Partition values must remain a single safe path component.
+RUN_TYPE=$(printf '%s' "$RUN_TYPE" | tr -cs 'A-Za-z0-9._-' '_')
+
 # Extract connection details for display
 CONN_HOST=$(grep -E "^HOSTNAME=|^mainhost=" "$CONNECTION_FILE" 2>/dev/null | head -1 | cut -d= -f2)
 CONN_ENGINE=$(grep -E "^# Engine:" "$CONNECTION_FILE" 2>/dev/null | cut -d: -f2 | tr -d ' ')
@@ -277,6 +321,7 @@ echo ""
 echo -e "  ${BOLD}Test${NC}"
 echo "    Plan:       $(basename "$TEST_PLAN")"
 echo "    Type:       ${TEST_TYPE}"
+echo "    Run type:   ${RUN_TYPE}"
 echo "    Queries:    $(basename "$QUERY_FILE") (${QUERY_COUNT} queries)"
 [ -n "${METADATA_FILE:-}" ] && echo "    Metadata:   $(basename "$METADATA_FILE")"
 echo ""
@@ -396,8 +441,17 @@ fi
 echo -e "${BLUE}Running JMeter...${NC}"
 echo ""
 
-# Run JMeter
+# Run JMeter. Preserve its status but continue through report capture and output
+# normalization so failed starts/runs leave useful diagnostics behind.
+set +e
 "${JMETER_CMD[@]}"
+JMETER_RC=$?
+set -e
+RUN_FAILED=0
+if [ "$JMETER_RC" -ne 0 ]; then
+    RUN_FAILED=1
+    echo -e "${RED}JMeter exited with status ${JMETER_RC}; finalizing available artifacts.${NC}"
+fi
 
 # Capture a standard run report alongside the raw results, so every run is
 # self-describing and the analysis does not depend on anyone remembering to run
@@ -412,12 +466,23 @@ if [ -f "${PROJECT_ROOT}/utilities/capture_run_report.py" ]; then
         CAPTURE_ARGS+=(--profile "$LOAD_PROFILE")
     fi
     CAPTURE_ARGS+=(--meta "engine=${ENGINE:-unknown}" --meta "cluster_size=${CLUSTER_SIZE:-unknown}")
-    CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}")
-    CAPTURE_ARGS+=(--meta "test_plan=$(basename "$TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
+    CAPTURE_ARGS+=(--meta "benchmark=${BENCHMARK_TYPE:-unknown}" --meta "run_type=${RUN_TYPE}")
+    CAPTURE_ARGS+=(--meta "test_plan=$(basename "$ORIGINAL_TEST_PLAN")" --meta "queries=$(basename "$QUERY_FILE")")
+    [ -n "${GENERATED_PLAN:-}" ] && CAPTURE_ARGS+=(--meta "generated_plan=$(basename "$GENERATED_PLAN")")
+    QUERY_SHA=$(python3 "${PROJECT_ROOT}/utilities/query_file_info.py" "$QUERY_FILE" --field sha256)
+    CAPTURE_ARGS+=(--meta "query_sha256=${QUERY_SHA}" --meta "requested_concurrency=${CONCURRENT_QUERY_COUNT}")
+    CAPTURE_ARGS+=(--meta "requested_qps=${QPS}" --meta "requested_qpm=${QPM}")
+    CAPTURE_ARGS+=(--meta "hold_period=${HOLD_PERIOD}" --meta "ramp_up_time=${RAMP_UP_TIME}" --meta "ramp_up_steps=${RAMP_UP_STEPS}")
+    CAPTURE_ARGS+=(--meta "max_concurrency=${MAX_CONCURRANCY}" --meta "recycle_on_eof=${RECYCLE_ON_EOF}" --meta "random_order=${RANDOM_ORDER}")
+    CAPTURE_ARGS+=(--meta "jmeter_version=$(basename "$JMETER_HOME")" --meta "java_version=$(java -version 2>&1 | head -1)")
+    CAPTURE_ARGS+=(--meta "git_commit=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)")
+    if [ -n "${LOAD_PROFILE:-}" ] && [ -f "$LOAD_PROFILE" ] \
+       && grep -qE "FreeFormArrivalsThreadGroup|UltimateThreadGroup" "$TEST_PLAN" 2>/dev/null; then
+        CAPTURE_ARGS+=(--meta "profile=$(basename "$LOAD_PROFILE")" --meta "profile_sha256=$(python3 "${PROJECT_ROOT}/utilities/query_file_info.py" "$LOAD_PROFILE" --field sha256)")
+    fi
     # Exit 2 from the report means the run itself failed (no samples, or an error
     # rate above MAX_ERROR_PCT). Propagate it: a run where the queries did not
     # succeed must not report success, or callers and CI treat it as a result.
-    RUN_FAILED=0
     set +e
     python3 "${PROJECT_ROOT}/utilities/capture_run_report.py" "${CAPTURE_ARGS[@]}"
     CAPTURE_RC=$?
@@ -456,14 +521,18 @@ fi
 echo ""
 echo "  Results:   ${REPORT_DIR}/"
 echo "  Report:    ${REPORT_DIR}/run_report.md"
-echo "  Dashboard: ${REPORT_DIR}/dashboard/index.html"
+if [ "${GENERATE_DASHBOARD:-true}" != "false" ]; then
+    echo "  Dashboard: ${REPORT_DIR}/dashboard/index.html"
+else
+    echo "  Dashboard: disabled"
+fi
 
 # Copy to S3 if enabled
-if [ "${COPY_TO_S3}" = "true" ] && [ -n "${S3_BASE_PATH:-}" ]; then
+if [ "${COPY_TO_S3}" = "true" ] && [ -n "${S3_UPLOAD_ROOT:-}" ]; then
     ENGINE_VAL="${ENGINE:-unknown}"
     CLUSTER_SIZE_VAL="${CLUSTER_SIZE:-unknown}"
     BENCHMARK_VAL="${BENCHMARK_TYPE:-unknown}"
-    S3_DEST="${S3_BASE_PATH}/engine=${ENGINE_VAL}/cluster_size=${CLUSTER_SIZE_VAL}/benchmark=${BENCHMARK_VAL}/run_id=${TIMESTAMP}/"
+    S3_DEST="${S3_UPLOAD_ROOT%/}/engine=${ENGINE_VAL}/cluster_size=${CLUSTER_SIZE_VAL}/benchmark=${BENCHMARK_VAL}/run_type=${RUN_TYPE}/run_id=${TIMESTAMP}/"
 
     echo ""
     echo "Uploading results to S3..."

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/run_test.sh
@@ -339,7 +339,11 @@ JMETER_CMD=("$JMETER_HOME/bin/jmeter" -n)
 JMETER_CMD+=(-t "$TEST_PLAN")
 JMETER_CMD+=(-q "$CONNECTION_FILE")
 JMETER_CMD+=(-l "${REPORT_DIR}/JmeterResultFile.csv")
-JMETER_CMD+=(-e -o "${REPORT_DIR}/dashboard")
+# HTML dashboard is ~3.5MB of vendored assets per run. CLAUDE.md documents
+# GENERATE_DASHBOARD=false to skip it; honour that here.
+if [ "${GENERATE_DASHBOARD:-true}" != "false" ]; then
+    JMETER_CMD+=(-e -o "${REPORT_DIR}/dashboard")
+fi
 
 # Pass all test parameters as JMeter -J properties
 JMETER_CMD+=("-JQUERY_PATH=$QUERY_FILE")

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/setup_jmeter.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/setup_jmeter.sh
@@ -377,17 +377,33 @@ fi
 # Copy custom JDBC drivers from jdbc_drivers/ directory
 JDBC_DRIVERS_DIR="${SCRIPT_DIR}/jdbc_drivers"
 if [ -d "${JDBC_DRIVERS_DIR}" ]; then
-    # Remove any existing e6 driver first. Copying without this leaves several
-    # versions in lib/ext/ and the JVM loads whichever it finds first, which
-    # fails as "UNIMPLEMENTED: No cluster-name header or unknown cluster".
+    # Remove any existing e6 driver first. Leaving several versions in lib/ext/
+    # makes the JVM load whichever it finds first, which fails as
+    # "UNIMPLEMENTED: No cluster-name header or unknown cluster".
     if ls "${JDBC_DRIVERS_DIR}"/e6-jdbc-driver-*.jar >/dev/null 2>&1; then
         rm -f "${JMETER_DIR}"/lib/ext/e6-jdbc-driver-*.jar
         rm -f "${JMETER_DIR}"/lib/e6-jdbc-driver-*.jar
     fi
 
-    cp -v "${JDBC_DRIVERS_DIR}"/*.jar "${JMETER_DIR}/lib/ext/" 2>/dev/null || {
-        echo "  No custom JDBC drivers found in jdbc_drivers/"
-    }
+    # Copy every jar EXCEPT the e6 driver, then add back only the newest e6 one.
+    # Copying jdbc_drivers/*.jar wholesale re-creates the collision above the
+    # moment two e6 versions sit side by side in the directory.
+    for jar in "${JDBC_DRIVERS_DIR}"/*.jar; do
+        [ -e "$jar" ] || continue
+        case "$(basename "$jar")" in
+            e6-jdbc-driver-*.jar) continue ;;
+        esac
+        cp -v "$jar" "${JMETER_DIR}/lib/ext/"
+    done
+
+    E6_LATEST=$(ls -1 "${JDBC_DRIVERS_DIR}"/e6-jdbc-driver-*.jar 2>/dev/null | sort -V | tail -1)
+    if [ -n "${E6_LATEST}" ]; then
+        E6_COUNT=$(ls -1 "${JDBC_DRIVERS_DIR}"/e6-jdbc-driver-*.jar 2>/dev/null | wc -l | tr -d ' ')
+        if [ "${E6_COUNT}" -gt 1 ]; then
+            echo "  NOTE: ${E6_COUNT} e6 driver versions present; installing only $(basename "${E6_LATEST}")"
+        fi
+        cp -v "${E6_LATEST}" "${JMETER_DIR}/lib/ext/"
+    fi
 
     # Resolve Netty/gRPC collisions introduced by fat "-with-dependencies" jars
     if [ -x "${SCRIPT_DIR}/utilities/fix_jmeter_jar_conflicts.sh" ]; then

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_configs/sample_benchmark.env
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_configs/sample_benchmark.env
@@ -1,0 +1,29 @@
+# Reusable benchmark configuration
+#
+# Copy to test_configs/my_benchmark.env, change CONNECTION_FILE and QUERY_FILE,
+# then select a workload model by overriding TEST_PLAN and one or two settings.
+
+CONNECTION_FILE=connection_properties/my_connection.properties
+QUERY_FILE=data_files/my_queries.csv
+TEST_PLAN=Test-Plans/Test-Plan-Maintain-static-concurrency.jmx
+
+# Common safe starting values
+CONCURRENT_QUERY_COUNT=2
+QPS=1
+QPM=60
+HOLD_PERIOD=60
+RAMP_UP_TIME=1
+RAMP_UP_STEPS=1
+MAX_CONCURRANCY=50
+QUERY_TIMEOUT=300
+LIMIT_RESULTSET=1000
+RANDOM_ORDER=false
+RECYCLE_ON_EOF=true
+GENERATE_DASHBOARD=false
+MAX_ERROR_PCT=5
+
+# The selected profile format must match the selected profile-driven plan.
+LOAD_PROFILE=test_properties/load_profile.csv
+
+COPY_TO_S3=false
+# S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_configs/sample_concurrency_test.env
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_configs/sample_concurrency_test.env
@@ -22,3 +22,5 @@ RECYCLE_ON_EOF=false
 
 # S3 upload (default: disabled)
 COPY_TO_S3=false
+# S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
+# RUN_TYPE=concurrency_4  # inferred when omitted

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_configs/sample_qps_test.env
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_configs/sample_qps_test.env
@@ -20,3 +20,5 @@ RECYCLE_ON_EOF=true
 
 # S3 upload (default: disabled)
 COPY_TO_S3=false
+# S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
+# RUN_TYPE=qps_5  # inferred when omitted

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_12_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_12_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=150
-MAX_POOL=75
 
 # Enhanced JDBC Debug Logging for DBR-specific issues
 log_level.org.apache.commons.dbcp2=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_12_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_12_test.properties
@@ -1,74 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=true
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=12
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=150
-
-# Enhanced JDBC Debug Logging for DBR-specific issues
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource Debug
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading Debug
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine Debug for DataSource Registration
-log_level.org.apache.jmeter.engine=INFO
-log_level.org.apache.jmeter.config=ERROR
-
-# Force early JDBC driver loading debug
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_16_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_16_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=200
-MAX_POOL=100
 
 # Enhanced JDBC Debug Logging for DBR-specific issues
 log_level.org.apache.commons.dbcp2=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_16_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_16_test.properties
@@ -1,74 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=true
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=16
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=200
-
-# Enhanced JDBC Debug Logging for DBR-specific issues
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource Debug
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading Debug
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine Debug for DataSource Registration
-log_level.org.apache.jmeter.engine=INFO
-log_level.org.apache.jmeter.config=ERROR
-
-# Force early JDBC driver loading debug
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_1_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_1_test.properties
@@ -1,81 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=true
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=1
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=20
-
-# Minimal logging for production (ERROR level to minimize log size)
-# Only log errors and critical issues - no warnings or info messages
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource logging
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine for DataSource Registration
-log_level.org.apache.jmeter.engine=ERROR
-log_level.org.apache.jmeter.config=ERROR
-
-# Suppress verbose thread start/stop logging
-log_level.org.apache.jmeter.threads=ERROR
-log_level.org.apache.jmeter.config.CSVDataSet=ERROR
-log_level.org.apache.jmeter.threads.JMeterThread=ERROR
-log_level.org.apache.jorphan.util=ERROR
-
-# Root logger - only errors
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_1_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_1_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=20
-MAX_POOL=10
 
 # Minimal logging for production (ERROR level to minimize log size)
 # Only log errors and critical issues - no warnings or info messages

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_2_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_2_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=30
-MAX_POOL=15
 
 # Enhanced JDBC Debug Logging for DBR-specific issues
 log_level.org.apache.commons.dbcp2=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_2_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_2_test.properties
@@ -1,74 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=true
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=2
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=30
-
-# Enhanced JDBC Debug Logging for DBR-specific issues
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource Debug
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading Debug
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine Debug for DataSource Registration
-log_level.org.apache.jmeter.engine=INFO
-log_level.org.apache.jmeter.config=ERROR
-
-# Force early JDBC driver loading debug
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_4_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_4_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=50
-MAX_POOL=25
 
 # Enhanced JDBC Debug Logging for DBR-specific issues
 log_level.org.apache.commons.dbcp2=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_4_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_4_test.properties
@@ -1,74 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=true
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=4
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=50
-
-# Enhanced JDBC Debug Logging for DBR-specific issues
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource Debug
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading Debug
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine Debug for DataSource Registration
-log_level.org.apache.jmeter.engine=INFO
-log_level.org.apache.jmeter.config=ERROR
-
-# Force early JDBC driver loading debug
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_8_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_8_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=100
-MAX_POOL=50
 
 # Enhanced JDBC Debug Logging for DBR-specific issues
 log_level.org.apache.commons.dbcp2=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_8_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/concurrency_8_test.properties
@@ -1,74 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=true
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=8
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=100
-
-# Enhanced JDBC Debug Logging for DBR-specific issues
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource Debug
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading Debug
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine Debug for DataSource Registration
-log_level.org.apache.jmeter.engine=INFO
-log_level.org.apache.jmeter.config=ERROR
-
-# Force early JDBC driver loading debug
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_run_once.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_run_once.properties
@@ -1,31 +1,68 @@
-# HTTP Endpoint Test - Run Each Query Once
-# This configuration runs each query in the CSV exactly once per thread
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
-# Concurrency - number of concurrent threads
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
+JMETER_HOME=
+
+# Directory that per-run report folders are created under.
+REPORT_PATH=reports
+
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
+S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
+
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=1
 
-# Iterations - set to 1 to run through CSV only once (no looping)
-ITERATIONS=1
-
-# Ramp up settings (in seconds for HTTP endpoint test plan)
-# Set to 0 to start immediately
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=0
 RAMP_UP_STEPS=1
 
-# Hold period - set this long enough for all queries to complete
-# For 4 queries: ~60 seconds, for 51 queries: ~2400 seconds (40 min)
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=120
 
-# DO NOT recycle - each query runs only once per thread
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
+QPS=1
+
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
+LOAD_PROFILE=test_properties/load_profile.csv
+
+# Pick queries from the CSV in random order instead of file order.
+RANDOM_ORDER=false
+
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-# Stop thread when CSV EOF is reached
-STOP_THREAD_ON_EOF=true
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/E6Data_TPCDS_queries_29_1TB.csv
 
-# Query execution settings
-RANDOM_ORDER=false
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
 
-# Query file path - override this with -JQUERY_PATH on command line
-QUERY_PATH=data_files/E6_TPCDS_1TB_Optimised_2col.csv
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
+MAX_CONCURRANCY=900

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_run_once_10threads.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_run_once_10threads.properties
@@ -1,12 +1,68 @@
-# HTTP Endpoint Test - Run Each Query Once with 10 threads
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
+
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
+JMETER_HOME=
+
+# Directory that per-run report folders are created under.
+REPORT_PATH=reports
+
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
+S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
+
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=10
-ITERATIONS=1
+
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=0
 RAMP_UP_STEPS=1
+
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
-RECYCLE_ON_EOF=false
-STOP_THREAD_ON_EOF=true
+
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
+QPS=1
+
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
+LOAD_PROFILE=test_properties/load_profile.csv
+
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
+
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
+RECYCLE_ON_EOF=false
+
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/E6Data_TPCDS_queries_29_1TB.csv
+
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
-QUERY_PATH=data_files/E6_TPCDS_1TB_Optimised_2col.csv
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
+MAX_CONCURRANCY=900

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_simple_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_simple_test.properties
@@ -1,31 +1,68 @@
-# HTTP Endpoint Simple Test properties - Low load for functionality testing
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-# Report directory path
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-# Copy to S3
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
 COPY_TO_S3=false
-S3_REPORT_PATH=s3://jmeter-reports
+S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-# Low load profile for testing
-LOAD_PROFILE=test_properties/load_profile.csv
-
-# Query configuration
-QUERY_PATH=data_files/http_endpoint_test_queries.csv
-RANDOM_ORDER=false
-RECYCLE_ON_EOF=true
-
-# Resource limits
-QUERY_TIMEOUT=30
-LIMIT_RESULTSET=100
-MAX_CONCURRANCY=10
-
-# Simple test configuration - very low load
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=1
+
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
+
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=1
+
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
+
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
 QPM=60
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
+LOAD_PROFILE=test_properties/load_profile.csv
+
+# Pick queries from the CSV in random order instead of file order.
+RANDOM_ORDER=false
+
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
+RECYCLE_ON_EOF=true
+
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_jmeter_queries.csv
+
+# Per-query timeout in SECONDS.
+QUERY_TIMEOUT=30
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
+LIMIT_RESULTSET=100
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
+MAX_CONCURRANCY=10

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/http_endpoint_test.properties
@@ -1,30 +1,68 @@
-# HTTP Endpoint Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-# Report directory path
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-# Copy to S3
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
 COPY_TO_S3=false
-S3_REPORT_PATH=s3://jmeter-reports
+S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-# Load Profile for QPS on arrivals
-LOAD_PROFILE=test_properties/load_profile.csv
-
-# Query configuration
-QUERY_PATH=data_files/test_queries_simple.csv
-RANDOM_ORDER=false
-RECYCLE_ON_EOF=true
-
-# Resource limits
-QUERY_TIMEOUT=300
-LIMIT_RESULTSET=1000
-MAX_CONCURRANCY=100
-
-# HTTP Endpoint specific (these may not be used but keeping for compatibility)
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=5
+
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
+
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=5
+
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=2
+
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
+LOAD_PROFILE=test_properties/load_profile.csv
+
+# Pick queries from the CSV in random order instead of file order.
+RANDOM_ORDER=false
+
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
+RECYCLE_ON_EOF=true
+
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/simple_queries.csv
+
+# Per-query timeout in SECONDS.
+QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
+LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
+MAX_CONCURRANCY=100

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/load_profile.csv
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/load_profile.csv
@@ -1,0 +1,7 @@
+StartValue,EndValue,Duration
+1,1,5
+2,2,5
+3,3,5
+4,4,5
+2,2,5
+1,1,5

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/load_profile_5min.csv
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/load_profile_5min.csv
@@ -1,0 +1,6 @@
+StartValue,EndValue,Duration
+1,1,60
+1,4,60
+4,4,60
+4,1,60
+1,1,60

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
@@ -6,7 +6,7 @@ JMETER_HOME=
 REPORT_PATH=reports
 
 #Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=false
+COPY_TO_S3=true
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
 #Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
@@ -17,7 +17,7 @@ RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
 #Total time to run the test in minutes i.e hold the load. This is after ramp up time
-HOLD_PERIOD=60
+HOLD_PERIOD=300
 
 #Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
 QPM=30
@@ -48,7 +48,7 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 # These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
-MAX_CONCURRANCY=200
+MAX_CONCURRANCY=1000
 MAX_POOL=50
 
 # Enhanced JDBC Debug Logging for DBR-specific issues

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
@@ -1,74 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
-COPY_TO_S3=true
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
+COPY_TO_S3=false
 S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=8
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/qps_load_profile_s3.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=true
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=1000
-
-# Enhanced JDBC Debug Logging for DBR-specific issues
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource Debug
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading Debug
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine Debug for DataSource Registration
-log_level.org.apache.jmeter.engine=INFO
-log_level.org.apache.jmeter.config=ERROR
-
-# Force early JDBC driver loading debug
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=1000
-MAX_POOL=50
 
 # Enhanced JDBC Debug Logging for DBR-specific issues
 log_level.org.apache.commons.dbcp2=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/qps_loadprofile_s3_test.properties
@@ -1,0 +1,75 @@
+# E6 Jmeter Test properties
+
+JMETER_HOME=
+
+#Change below for Report directory path. Reports will be written in this directory
+REPORT_PATH=reports
+
+#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
+COPY_TO_S3=false
+S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
+
+#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+CONCURRENT_QUERY_COUNT=8
+
+#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency
+RAMP_UP_TIME=1
+RAMP_UP_STEPS=1
+
+#Total time to run the test in minutes i.e hold the load. This is after ramp up time
+HOLD_PERIOD=60
+
+#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
+QPM=30
+
+#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+QPS=1
+
+#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+LOAD_PROFILE=test_properties/qps_load_profile_s3.csv
+
+
+#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)
+# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
+
+#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
+threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
+
+#To select queries from the CSV in Random Order set below to true
+RANDOM_ORDER=false
+
+#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration
+RECYCLE_ON_EOF=true
+
+#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
+QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+
+
+# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+QUERY_TIMEOUT=300
+LIMIT_RESULTSET=1000
+MAX_CONCURRANCY=200
+MAX_POOL=50
+
+# Enhanced JDBC Debug Logging for DBR-specific issues
+log_level.org.apache.commons.dbcp2=ERROR
+log_level.org.apache.jmeter.protocol.jdbc=ERROR
+log_level.com.databricks=ERROR
+log_level.com.databricks.client.jdbc=ERROR
+
+# JMeter JDBC Configuration and DataSource Debug
+log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
+log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
+log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
+
+# Connection Pool and Driver Loading Debug
+log_level.org.apache.commons.pool2=ERROR
+log_level.java.sql=ERROR
+log_level.org.apache.jmeter.testelement=ERROR
+
+# JMeter Engine Debug for DataSource Registration
+log_level.org.apache.jmeter.engine=INFO
+log_level.org.apache.jmeter.config=ERROR
+
+# Force early JDBC driver loading debug
+log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sample_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sample_test.properties
@@ -49,7 +49,6 @@ QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=900
-MAX_POOL=300
 
 # Enhanced JDBC Debug Logging for DBR-specific issues
 log_level.org.apache.commons.dbcp2=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sample_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sample_test.properties
@@ -1,74 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
 COPY_TO_S3=false
-S3_REPORT_PATH=s3://jmeter-reports
+S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=2
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency 
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=1
 RAMP_UP_STEPS=1
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time 
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=300
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=30
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=30
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime) 
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration 
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
-QUERY_PATH=data_files/Jmeter_15-queries-sub-2-sec_v3.csv
+# Query CSV to run. Override per run with QUERY_FILE=...
+QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=900
-
-# Enhanced JDBC Debug Logging for DBR-specific issues
-log_level.org.apache.commons.dbcp2=ERROR
-log_level.org.apache.jmeter.protocol.jdbc=ERROR
-log_level.com.databricks=ERROR
-log_level.com.databricks.client.jdbc=ERROR
-
-# JMeter JDBC Configuration and DataSource Debug
-log_level.org.apache.jmeter.protocol.jdbc.config.DataSourceElement=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.sampler.JDBCSampler=ERROR
-log_level.org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement=ERROR
-
-# Connection Pool and Driver Loading Debug
-log_level.org.apache.commons.pool2=ERROR
-log_level.java.sql=ERROR
-log_level.org.apache.jmeter.testelement=ERROR
-
-# JMeter Engine Debug for DataSource Registration
-log_level.org.apache.jmeter.engine=INFO
-log_level.org.apache.jmeter.config=ERROR
-
-# Force early JDBC driver loading debug
-log_level.root=ERROR

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sequential_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sequential_test.properties
@@ -49,4 +49,3 @@ QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 QUERY_TIMEOUT=300
 LIMIT_RESULTSET=1000
 MAX_CONCURRANCY=900
-MAX_POOL=300

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sequential_test.properties
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/sequential_test.properties
@@ -1,51 +1,68 @@
-# E6 Jmeter Test properties
+# e6data JMeter test properties
+#
+# Every value here can be overridden from the environment, e.g.
+#     CONCURRENT_QUERY_COUNT=8 HOLD_PERIOD=600 ./run_test.sh
+# Environment wins over this file. All times are in SECONDS unless noted.
 
+# Leave blank to use the bundled apache-jmeter-5.6.3 in this directory.
 JMETER_HOME=
 
-#Change below for Report directory path. Reports will be written in this directory
+# Directory that per-run report folders are created under.
 REPORT_PATH=reports
 
-#Chage below to copy the reports to s3. The copy script will use the aws configure credentials, so you should run aws creds in env set.
+# Upload results to S3 after the run. Needs valid AWS credentials in the
+# environment. Leave false unless you have set S3_REPORT_PATH to your bucket.
 COPY_TO_S3=false
-S3_REPORT_PATH=s3://jmeter-reports
+S3_REPORT_PATH=s3://your-s3-bucket/jmeter-results
 
-#Change below for concurrency based test plan which will maintain this concurrency. This applicable only for concurrency based plan
+# Number of queries running at once.
+# Used by: Run-Once-static-concurrency, Maintain-static-concurrency.
 CONCURRENT_QUERY_COUNT=1
 
-#Change below if u want to add RAMP_TIME(min) and RAMP_UP_STEPS (counts) to reach target concurrency 
+# SECONDS to reach the target concurrency, and how many steps to do it in.
+# Used by: Maintain-static-concurrency, the QPS/QPM arrivals plans.
 RAMP_UP_TIME=0
 RAMP_UP_STEPS=0
 
-#Total time to run the test in minutes i.e hold the load. This is after ramp up time 
+# How long to hold the load, in SECONDS, measured after ramp-up.
+# EXCEPTION: Constant-QPM-On-Arrivals runs on Unit=M, so there this value is
+# in MINUTES. HOLD_PERIOD=5 on that plan means 5 minutes, not 5 seconds.
+# Not used by Run-Once (bounded by query count) or the load-profile plans
+# (bounded by the profile).
 HOLD_PERIOD=100
 
-#Change below for QPM based Test Plan which will fire below number of queries per minute. This is applicable only for static QPM based test Plan
-QPM=1
-
-#Change below for QPS based Test Plan which will fire below number of queries per sec. This is applicable only for static QPS based test Plan
+# Queries per SECOND. Used by: Constant-QPS-On-Arrivals and its JSR variant.
 QPS=1
 
-#Change below for load_profile based Test Plan. This will be applicable only if u select the load profile based test plan i.e QPS/QPM on arrivals.
+# Queries per MINUTE. Used by: Constant-QPM-On-Arrivals.
+QPM=1
+
+# Load profile CSV for the two profile-driven plans. The format is chosen from
+# the plan automatically:
+#   Fire-QPS-with-load-profile                     3 cols  StartValue,EndValue,Duration
+#   Maintain-variable-concurrency-with-load-profile 5 cols  Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+# The runner injects this into a copy of the plan before JMeter starts and keeps
+# that copy in the run directory. Look for 'load profile applied:' in the output.
 LOAD_PROFILE=test_properties/load_profile.csv
 
-
-#Change below for variable concurrency test plan, The UTG thread will use special property: spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime) 
-# Example : threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)
-
-#threads_schedule=spawn(10,0s,30s,60s,10s) spawn(20,90s,30s,60s,10s)
-threads_schedule=spawn(4,0s,0s,80s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,120s,0s) spawn(16,0s,0s,80s,0s) spawn(4,0s,0s,180s,0s)
-
-#To select queries from the CSV in Random Order set below to true
+# Pick queries from the CSV in random order instead of file order.
 RANDOM_ORDER=false
 
-#Set below variable to true if you want to Repeat the queries in the CSV, this essentially means queries will repeat till the test duration 
+# Repeat the query file when it runs out. Required true for any time-bounded or
+# profile-driven plan, otherwise threads finish early and the load stops.
 RECYCLE_ON_EOF=false
 
-#Change below to the absolute path of your query file. This will be the query file used unless overwritten.
+# Query CSV to run. Override per run with QUERY_FILE=...
 QUERY_PATH=data_files/sample_Jmeter_15-queries-sub-2-sec_v3_without_header.csv
 
-
-# These values are only to control the jmeter tests running out of resources, Change if required carefully as per machine resources
+# Per-query timeout in SECONDS.
 QUERY_TIMEOUT=300
+
+# Max rows read per query. Queries returning more are under-timed, because the
+# client stops fetching early.
 LIMIT_RESULTSET=1000
+
+# Upper bound on simultaneous in-flight queries for the arrivals-based plans.
+# Must exceed peak_rate x average_latency_seconds or arrivals are dropped and
+# the run report shows a SHORTFALL. (Spelling kept for backwards compatibility.)
 MAX_CONCURRANCY=900

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/utg_load_profile.csv
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/utg_load_profile.csv
@@ -1,0 +1,3 @@
+Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+10,0,30,60,10
+20,90,30,60,10

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/utg_load_profile_5min.csv
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/test_properties/utg_load_profile_5min.csv
@@ -1,0 +1,4 @@
+Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+2,0,0,300,0
+2,60,0,180,0
+2,120,0,60,0

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
@@ -54,6 +54,18 @@ HOLD_PERIOD=60           # seconds; must be >= the profile's total duration
 
 CSV format (header optional): `StartValue,EndValue,Duration`, duration in seconds.
 
+**You do not need a properties file per profile.** Environment values override the file, so one
+config serves every profile:
+
+```bash
+LOAD_PROFILE=test_properties/spike.csv ./run_jmeter_tests_interactive.sh
+LOAD_PROFILE=test_properties/spike.csv ./run_test.sh test_configs/my.env
+```
+
+Both runners print what was overridden. Also overridable this way: `HOLD_PERIOD`,
+`MAX_CONCURRANCY`, `COPY_TO_S3`, `RECYCLE_ON_EOF`, `RANDOM_ORDER`, `QPS`, `QPM`,
+`CONCURRENT_QUERY_COUNT`, `RAMP_UP_TIME`, `RAMP_UP_STEPS`, `QUERY_TIMEOUT`.
+
 **Why this is needed:** the plan ships a JSR223 PreProcessor that tries to apply the profile
 via `ctx.getThreadGroup().setData()`. A PreProcessor runs when a sampler fires, by which point
 the thread group has already read its `Schedule` — so the CSV was silently ignored and the

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
@@ -61,6 +61,25 @@ plan's hardcoded schedule (25 arrivals over 15s) was used instead. The schedule 
 injected before JMeter launches. The generated plan is written into the run's own
 `reports/<timestamp>/` directory as a per-run artifact.
 
+Verify the queries actually fired at the requested rate:
+
+```bash
+python3 utilities/verify_load_profile.py \
+  reports/<timestamp>/JmeterResultFile.csv test_properties/my_profile.csv
+```
+
+JMeter's `timeStamp` column is each sample's *start* time, so bucketing it per second
+reconstructs the true arrival curve — unaffected by how long queries took to finish, which
+matters because a saturated cluster stretches completions well past the profile window.
+
+```
+ sec | expected | actual |
+   8 |       56 |     56 | ########################################################
+...
+expected : 482
+actual   : 480  (99.6%)
+```
+
 Confirm what was applied — the line is printed on every run:
 
 ```

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
@@ -39,23 +39,34 @@ Comprehensive guide to all utility scripts for analyzing, comparing, and managin
 
 | Script | Purpose |
 |--------|---------|
-| `apply_load_profile.py` | Inject a load-profile CSV into a plan's arrivals `Schedule` before JMeter starts |
+| `apply_load_profile.py` | Inject a load-profile CSV into a plan's thread-group schedule before JMeter starts |
 | `capture_run_report.py` | Write `run_summary.json` + `run_report.md` into a run dir (called automatically by both runners) |
 | `verify_load_profile.py` | Confirm arrivals matched the profile, per second |
 | `analyze_queue_buildup.py` | Queue depth / drain reconstruction for arrivals runs |
 
 Called automatically by `run_jmeter_tests_interactive.sh` and `run_test.sh` whenever the
-selected plan contains a `FreeFormArrivalsThreadGroup`. Point `LOAD_PROFILE` in your test
-properties at any CSV — no per-profile test plan is needed.
+selected plan contains a `FreeFormArrivalsThreadGroup` or an `UltimateThreadGroup`. Point
+`LOAD_PROFILE` at any CSV — no per-profile test plan is needed.
+
+Two formats, chosen from the plan rather than a flag (header optional, times in seconds):
+
+| Plan controls | Thread group | Block rewritten | CSV columns |
+|---|---|---|---|
+| arrival rate | `FreeFormArrivalsThreadGroup` | `Schedule` | `StartValue,EndValue,Duration` |
+| concurrency | `UltimateThreadGroup` | `ultimatethreadgroupdata` | `Threads,StartTime,StartupTime,HoldTime,ShutdownTime` |
+
+Concurrency rows **stack** — each wave adds its threads on top of any still running — and
+ramp linearly over `StartupTime` / `ShutdownTime`. Set both to `0` for a flat step.
 
 ```properties
 LOAD_PROFILE=test_properties/my_profile.csv
-RECYCLE_ON_EOF=true      # required: without it threads hit EOF and vanish
-MAX_CONCURRANCY=200      # must exceed peak_qps x avg_latency_sec
-HOLD_PERIOD=60           # seconds; must be >= the profile's total duration
+RECYCLE_ON_EOF=true      # required for both: without it threads hit EOF and vanish
+MAX_CONCURRANCY=200      # arrivals plan only; must exceed peak_qps x avg_latency_sec
+HOLD_PERIOD=60           # arrivals plan only; >= the profile's total duration
 ```
 
-CSV format (header optional): `StartValue,EndValue,Duration`, duration in seconds.
+The concurrency plan ignores `MAX_CONCURRANCY` and `HOLD_PERIOD` — its CSV sets both the
+concurrency and the run length.
 
 **You do not need a properties file per profile.** Environment values override the file, so one
 config serves every profile:

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
@@ -35,6 +35,41 @@ Comprehensive guide to all utility scripts for analyzing, comparing, and managin
 | `convert_queries_for_jmeter_http.py` | Convert multiline SQL to single-line for JMeter HTTP API (no quote escaping) |
 | `convert_queries_for_json_api.py` | Convert multiline SQL to single-line with JSON/e6data fixes (backticks, keywords, CTEs) |
 
+### Load Profile
+
+| Script | Purpose |
+|--------|---------|
+| `apply_load_profile.py` | Inject a load-profile CSV into a plan's arrivals `Schedule` before JMeter starts |
+
+Called automatically by `run_jmeter_tests_interactive.sh` and `run_test.sh` whenever the
+selected plan contains a `FreeFormArrivalsThreadGroup`. Point `LOAD_PROFILE` in your test
+properties at any CSV — no per-profile test plan is needed.
+
+```properties
+LOAD_PROFILE=test_properties/my_profile.csv
+RECYCLE_ON_EOF=true      # required: without it threads hit EOF and vanish
+MAX_CONCURRANCY=200      # must exceed peak_qps x avg_latency_sec
+HOLD_PERIOD=60           # seconds; must be >= the profile's total duration
+```
+
+CSV format (header optional): `StartValue,EndValue,Duration`, duration in seconds.
+
+**Why this is needed:** the plan ships a JSR223 PreProcessor that tries to apply the profile
+via `ctx.getThreadGroup().setData()`. A PreProcessor runs when a sampler fires, by which point
+the thread group has already read its `Schedule` — so the CSV was silently ignored and the
+plan's hardcoded schedule (25 arrivals over 15s) was used instead. The schedule is now
+injected before JMeter launches. The generated plan is written into the run's own
+`reports/<timestamp>/` directory as a per-run artifact.
+
+Confirm what was applied — the line is printed on every run:
+
+```
+load profile applied: 15 steps, 17s, peak 56/s, ~482 expected samples
+```
+
+If actual samples fall well short of expected, the cluster is saturating and arrivals are
+being throttled by `MAX_CONCURRANCY`. That is a capacity result, not a tooling failure.
+
 ### Testing & Diagnostics (4)
 
 | Script | Purpose |

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
@@ -4,7 +4,7 @@ Comprehensive guide to all utility scripts for analyzing, comparing, and managin
 
 ## Script Inventory
 
-**43 scripts total** (22 top-level + 21 athena)
+**64 scripts total** (27 top-level + 37 athena)
 
 ### Analysis & Comparison (9)
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
@@ -4,7 +4,7 @@ Comprehensive guide to all utility scripts for analyzing, comparing, and managin
 
 ## Script Inventory
 
-**64 scripts total** (27 top-level + 37 athena)
+The inventory below is grouped by purpose. Counts are intentionally omitted because this directory evolves frequently; use `find utilities -type f` for the current file list.
 
 ### Analysis & Comparison (9)
 
@@ -115,7 +115,7 @@ load profile applied: 15 steps, 17s, peak 56/s, ~482 expected samples
 If actual samples fall well short of expected, the cluster is saturating and arrivals are
 being throttled by `MAX_CONCURRANCY`. That is a capacity result, not a tooling failure.
 
-### Testing & Diagnostics (4)
+### Testing & Diagnostics
 
 | Script | Purpose |
 |--------|---------|
@@ -123,12 +123,16 @@ being throttled by `MAX_CONCURRANCY`. That is a capacity result, not a tooling f
 | `test_dbr_connectivity.sh` | Diagnose DBR connectivity issues with repeated DNS/HTTPS tests |
 | `test_queries_http.py` | Test SQL queries via e6data HTTP API (bypasses JMeter) |
 | `fix_jmeter_jar_conflicts.sh` | Quarantine duplicate e6 JDBC drivers and zero-byte jars (`--dry-run` supported) |
+| `run_premerge_checks.sh` | Run unit, Python, shell, JMX, and profile-injection checks used by CI |
+| `run_smoke_suite.sh` | Run a bounded five-plan JDBC smoke suite against a real target |
 
 **When to run `fix_jmeter_jar_conflicts.sh`:** if every query fails instantly with
 `UNIMPLEMENTED: No cluster-name header or unknown cluster`, more than one
 `e6-jdbc-driver-*.jar` is probably on the classpath and an old one is winning.
 Load order depends on the filesystem, so this can reproduce on Linux but not macOS.
 Check with `find apache-jmeter-5.6.3 -name "e6-jdbc-driver-*.jar"` — more than one line means ambiguity.
+
+The checker also reports embedded SLF4J and Netty classes in fat JDBC drivers. Those are informational because removing individual classes from a signed/vendor artifact is unsafe; prefer a vendor-approved thin or correctly shaded driver when one becomes available.
 
 ### Housekeeping (3)
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/README.md
@@ -40,6 +40,9 @@ Comprehensive guide to all utility scripts for analyzing, comparing, and managin
 | Script | Purpose |
 |--------|---------|
 | `apply_load_profile.py` | Inject a load-profile CSV into a plan's arrivals `Schedule` before JMeter starts |
+| `capture_run_report.py` | Write `run_summary.json` + `run_report.md` into a run dir (called automatically by both runners) |
+| `verify_load_profile.py` | Confirm arrivals matched the profile, per second |
+| `analyze_queue_buildup.py` | Queue depth / drain reconstruction for arrivals runs |
 
 Called automatically by `run_jmeter_tests_interactive.sh` and `run_test.sh` whenever the
 selected plan contains a `FreeFormArrivalsThreadGroup`. Point `LOAD_PROFILE` in your test

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/analyze_queue_buildup.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/analyze_queue_buildup.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Show queue build-up and drain for an arrivals-based run.
+
+Usage:
+    analyze_queue_buildup.py <JmeterResultFile.csv> [--bucket N] [--markdown]
+
+Under a load profile the engine is deliberately pushed past its service rate, so
+the interesting result is not average latency but how the backlog forms and
+clears. This reconstructs, per time bucket:
+
+    arrivals    queries that started        (timeStamp)
+    completions queries that finished       (timeStamp + elapsed)
+    in-flight   arrivals - completions so far, i.e. queue depth + active
+    latency     mean elapsed of queries completing in that bucket
+
+Rising in-flight means arrivals are outrunning the engine. The peak is the
+worst-case backlog; the tail after arrivals stop is pure drain time.
+"""
+
+import argparse
+import csv
+import sys
+
+
+def load(path):
+    rows = list(csv.DictReader(open(path)))
+    if not rows:
+        raise SystemExit(f"{path}: no samples")
+    recs = []
+    for r in rows:
+        start = int(r["timeStamp"])
+        recs.append((start, start + int(r["elapsed"]), int(r["elapsed"])))
+    return recs
+
+
+def buckets(recs, width_ms):
+    t0 = min(r[0] for r in recs)
+    tend = max(r[1] for r in recs)
+    n = (tend - t0) // width_ms + 1
+    arrivals = [0] * n
+    completions = [0] * n
+    lat_sum = [0] * n
+    for start, end, elapsed in recs:
+        arrivals[(start - t0) // width_ms] += 1
+        b = (end - t0) // width_ms
+        completions[b] += 1
+        lat_sum[b] += elapsed
+    return t0, arrivals, completions, lat_sum
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("results")
+    ap.add_argument("--bucket", type=int, default=5, help="bucket width in seconds (default 5)")
+    ap.add_argument("--markdown", action="store_true")
+    args = ap.parse_args()
+
+    recs = load(args.results)
+    width = args.bucket * 1000
+    _, arrivals, completions, lat_sum = buckets(recs, width)
+
+    inflight, running = [], 0
+    for a, c in zip(arrivals, completions):
+        running += a - c
+        inflight.append(running)
+
+    peak = max(inflight)
+    peak_at = inflight.index(peak) * args.bucket
+    last_arrival = max(i for i, a in enumerate(arrivals) if a) * args.bucket
+    total_s = len(arrivals) * args.bucket
+
+    if args.markdown:
+        print(f"| t (s) | arrivals | completions | in-flight | mean latency (s) |")
+        print(f"|---|---|---|---|---|")
+    else:
+        print(f"{'t(s)':>5} {'arr':>5} {'done':>5} {'in-flight':>10}  {'lat(s)':>7}  queue")
+        print("-" * 78)
+
+    scale = max(1, peak // 40)
+    for i, (a, c, q) in enumerate(zip(arrivals, completions, inflight)):
+        lat = (lat_sum[i] / c / 1000) if c else 0
+        t = i * args.bucket
+        if args.markdown:
+            print(f"| {t} | {a} | {c} | {q} | {lat:.1f} |")
+        else:
+            print(f"{t:>5} {a:>5} {c:>5} {q:>10}  {lat:>7.1f}  {'#' * (q // scale)}")
+
+    print()
+    print(f"peak in-flight   : {peak} at t={peak_at}s")
+    print(f"arrivals stop    : t={last_arrival}s")
+    print(f"drain time       : {total_s - last_arrival}s after last arrival")
+    print(f"total wall clock : {total_s}s")
+    print(f"samples          : {len(recs)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Inject a load-profile CSV into a JMeter plan's arrivals-thread-group Schedule.
+
+Usage:
+    apply_load_profile.py <plan.jmx> <profile.csv> <output.jmx>
+
+Why this exists
+---------------
+Test-Plan-Fire-QPS-with-load-profile.jmx ships a JSR223 *PreProcessor* that
+tries to apply the load profile at runtime via ctx.getThreadGroup().setData().
+That cannot work: a PreProcessor runs when a sampler fires, which is after the
+FreeFormArrivalsThreadGroup has already read its Schedule and started firing
+arrivals. The result is that the CSV is silently ignored and the plan's
+hardcoded Schedule is used instead - typically 25 arrivals over 15s.
+
+Rather than restructuring the JMeter element lifecycle, this rewrites the
+Schedule block before JMeter is launched, so any CSV works with the stock plan
+and no per-profile plan files are needed.
+
+CSV format (header optional, matching the plan's own parser):
+    StartValue,EndValue,Duration
+    3,3,1
+    5,5,2
+
+Duration is in the unit set by the thread group's Unit property (S = seconds).
+"""
+
+import csv
+import re
+import sys
+
+
+def read_profile(path):
+    rows = []
+    with open(path, newline="") as fh:
+        for lineno, parts in enumerate(csv.reader(fh), 1):
+            if not parts or not any(p.strip() for p in parts):
+                continue
+            if parts[0].strip().lower().startswith("startvalue"):
+                continue  # header
+            if len(parts) < 3:
+                raise SystemExit(
+                    f"{path}:{lineno}: expected 3 columns, got {len(parts)}: {parts!r}"
+                )
+            try:
+                start, end, dur = (int(p.strip()) for p in parts[:3])
+            except ValueError:
+                raise SystemExit(f"{path}:{lineno}: non-integer value in {parts[:3]!r}")
+            if dur <= 0:
+                raise SystemExit(f"{path}:{lineno}: duration must be > 0, got {dur}")
+            rows.append((start, end, dur))
+    if not rows:
+        raise SystemExit(f"{path}: no usable rows found")
+    return rows
+
+
+def build_schedule(rows):
+    blocks = []
+    for i, (start, end, dur) in enumerate(rows):
+        blocks.append(
+            f'          <collectionProp name="lp{i}">\n'
+            f'            <stringProp name="48">{start}</stringProp>\n'
+            f'            <stringProp name="49">{end}</stringProp>\n'
+            f'            <stringProp name="50">{dur}</stringProp>\n'
+            f"          </collectionProp>"
+        )
+    return (
+        '<collectionProp name="Schedule">\n'
+        + "\n".join(blocks)
+        + "\n        </collectionProp>\n        "
+    )
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit(__doc__.strip())
+    plan_path, profile_path, out_path = sys.argv[1:4]
+
+    plan = open(plan_path).read()
+    if "FreeFormArrivalsThreadGroup" not in plan:
+        raise SystemExit(
+            f"{plan_path}: no FreeFormArrivalsThreadGroup - this plan is not "
+            f"load-profile driven, nothing to inject"
+        )
+
+    rows = read_profile(profile_path)
+    plan_out, n = re.subn(
+        r'<collectionProp name="Schedule">.*?</collectionProp>\s*(?=<stringProp name="LogFilename">)',
+        build_schedule(rows),
+        plan,
+        count=1,
+        flags=re.S,
+    )
+    if n != 1:
+        raise SystemExit(f"{plan_path}: could not locate the Schedule block to replace")
+
+    with open(out_path, "w") as fh:
+        fh.write(plan_out)
+
+    total = sum(start * dur for start, _, dur in rows)
+    duration = sum(dur for _, _, dur in rows)
+    peak = max(max(s, e) for s, e, _ in rows)
+    print(
+        f"load profile applied: {len(rows)} steps, {duration}s, "
+        f"peak {peak}/s, ~{total} expected samples -> {out_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
@@ -98,7 +98,9 @@ def main():
     with open(out_path, "w") as fh:
         fh.write(plan_out)
 
-    total = sum(start * dur for start, _, dur in rows)
+    # Trapezoid: a step ramping start->end over dur averages (start+end)/2.
+    # Using start alone under-reports any ramped step.
+    total = round(sum((start + end) / 2 * dur for start, end, dur in rows))
     duration = sum(dur for _, _, dur in rows)
     peak = max(max(s, e) for s, e, _ in rows)
     print(

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
@@ -1,29 +1,40 @@
 #!/usr/bin/env python3
 """
-Inject a load-profile CSV into a JMeter plan's arrivals-thread-group Schedule.
+Inject a load-profile CSV into a JMeter plan's thread-group schedule.
 
 Usage:
     apply_load_profile.py <plan.jmx> <profile.csv> <output.jmx>
 
 Why this exists
 ---------------
-Test-Plan-Fire-QPS-with-load-profile.jmx ships a JSR223 *PreProcessor* that
-tries to apply the load profile at runtime via ctx.getThreadGroup().setData().
-That cannot work: a PreProcessor runs when a sampler fires, which is after the
-FreeFormArrivalsThreadGroup has already read its Schedule and started firing
-arrivals. The result is that the CSV is silently ignored and the plan's
-hardcoded Schedule is used instead - typically 25 arrivals over 15s.
+Both load-profile plans ship a JSR223 *PreProcessor* that tries to apply the
+CSV at runtime via setData() / setProperty(). That cannot work: a PreProcessor
+runs when a sampler fires, which is after the thread group has already read its
+schedule and started threads. The CSV is silently ignored and the plan's
+hardcoded schedule is used instead.
 
 Rather than restructuring the JMeter element lifecycle, this rewrites the
-Schedule block before JMeter is launched, so any CSV works with the stock plan
+schedule block before JMeter is launched, so any CSV works with the stock plan
 and no per-profile plan files are needed.
 
-CSV format (header optional, matching the plan's own parser):
-    StartValue,EndValue,Duration
-    3,3,1
-    5,5,2
+Two plan families are supported; the format is chosen from the plan, not a flag.
 
-Duration is in the unit set by the thread group's Unit property (S = seconds).
+  FreeFormArrivalsThreadGroup  ->  <collectionProp name="Schedule">
+      Controls ARRIVAL RATE. 3 columns:
+          StartValue,EndValue,Duration
+          3,3,1
+          5,5,2
+
+  UltimateThreadGroup          ->  <collectionProp name="ultimatethreadgroupdata">
+      Controls CONCURRENCY. 5 columns:
+          Threads,StartTime,StartupTime,HoldTime,ShutdownTime
+          10,0,30,60,10
+          20,90,30,60,10
+      Rows STACK: a row adds its threads on top of whatever else is running,
+      so the two rows above give 10 concurrent, then 30 from t=90s.
+      For a flat step with no ramp use StartupTime=0 and ShutdownTime=0.
+
+Durations are in the unit set by the thread group's Unit property (S = seconds).
 """
 
 import csv
@@ -31,45 +42,161 @@ import re
 import sys
 
 
-def read_profile(path):
-    rows = []
+# ---------------------------------------------------------------- parsing
+
+def _rows(path, ncols, header_prefix):
+    """Read a CSV of exactly ncols integer columns, skipping a header if present."""
+    out = []
     with open(path, newline="") as fh:
         for lineno, parts in enumerate(csv.reader(fh), 1):
             if not parts or not any(p.strip() for p in parts):
                 continue
-            if parts[0].strip().lower().startswith("startvalue"):
+            if parts[0].strip().lower().startswith(header_prefix):
                 continue  # header
-            if len(parts) < 3:
+            if len(parts) < ncols:
                 raise SystemExit(
-                    f"{path}:{lineno}: expected 3 columns, got {len(parts)}: {parts!r}"
+                    f"{path}:{lineno}: expected {ncols} columns, "
+                    f"got {len(parts)}: {parts!r}"
                 )
             try:
-                start, end, dur = (int(p.strip()) for p in parts[:3])
+                out.append(tuple(int(p.strip()) for p in parts[:ncols]))
             except ValueError:
-                raise SystemExit(f"{path}:{lineno}: non-integer value in {parts[:3]!r}")
-            if dur <= 0:
-                raise SystemExit(f"{path}:{lineno}: duration must be > 0, got {dur}")
-            rows.append((start, end, dur))
-    if not rows:
+                raise SystemExit(
+                    f"{path}:{lineno}: non-integer value in {parts[:ncols]!r}"
+                )
+    if not out:
         raise SystemExit(f"{path}: no usable rows found")
+    return out
+
+
+def read_arrivals_profile(path):
+    rows = _rows(path, 3, "startvalue")
+    for start, end, dur in rows:
+        if dur <= 0:
+            raise SystemExit(f"{path}: duration must be > 0, got {dur}")
+        if start < 0 or end < 0:
+            raise SystemExit(f"{path}: arrival rate must be >= 0, got {start},{end}")
     return rows
 
 
+def read_concurrency_profile(path):
+    rows = _rows(path, 5, "threads")
+    for threads, start, startup, hold, shutdown in rows:
+        if threads <= 0:
+            raise SystemExit(f"{path}: Threads must be > 0, got {threads}")
+        if min(start, startup, hold, shutdown) < 0:
+            raise SystemExit(f"{path}: times must be >= 0 in row {rows!r}")
+        if hold <= 0:
+            raise SystemExit(f"{path}: HoldTime must be > 0, got {hold}")
+    return rows
+
+
+# ---------------------------------------------------------------- emitting
+
 def build_schedule(rows):
-    blocks = []
-    for i, (start, end, dur) in enumerate(rows):
-        blocks.append(
-            f'          <collectionProp name="lp{i}">\n'
-            f'            <stringProp name="48">{start}</stringProp>\n'
-            f'            <stringProp name="49">{end}</stringProp>\n'
-            f'            <stringProp name="50">{dur}</stringProp>\n'
-            f"          </collectionProp>"
-        )
+    """FreeFormArrivalsThreadGroup: 3 values per row."""
+    blocks = [
+        f'          <collectionProp name="lp{i}">\n'
+        f'            <stringProp name="48">{start}</stringProp>\n'
+        f'            <stringProp name="49">{end}</stringProp>\n'
+        f'            <stringProp name="50">{dur}</stringProp>\n'
+        f"          </collectionProp>"
+        for i, (start, end, dur) in enumerate(rows)
+    ]
     return (
         '<collectionProp name="Schedule">\n'
         + "\n".join(blocks)
         + "\n        </collectionProp>\n        "
     )
+
+
+def build_utg_data(rows):
+    """UltimateThreadGroup: 5 values per row.
+
+    Property names inside a collectionProp are positional filler - JMeter reads
+    the collection in order and ignores them. The stock plan writes name==value
+    (and even repeats a name within a row), so anything unique is safe.
+    """
+    blocks = []
+    for i, row in enumerate(rows):
+        vals = "\n".join(
+            f'            <stringProp name="c{i}_{j}">{v}</stringProp>'
+            for j, v in enumerate(row)
+        )
+        blocks.append(
+            f'          <collectionProp name="utg{i}">\n{vals}\n'
+            f"          </collectionProp>"
+        )
+    return (
+        '<collectionProp name="ultimatethreadgroupdata">\n'
+        + "\n".join(blocks)
+        + "\n        </collectionProp>\n        "
+    )
+
+
+# ---------------------------------------------------------------- reporting
+
+def describe_arrivals(rows):
+    # Trapezoid: a step ramping start->end over dur averages (start+end)/2.
+    total = round(sum((s + e) / 2 * d for s, e, d in rows))
+    duration = sum(d for _, _, d in rows)
+    peak = max(max(s, e) for s, e, _ in rows)
+    return (f"{len(rows)} steps, {duration}s, peak {peak}/s, "
+            f"~{total} expected samples")
+
+
+def concurrency_timeline(rows):
+    """Concurrency at each second, summing the stacked, ramped waves."""
+    end = max(st + up + hold + down for _, st, up, hold, down in rows)
+    series = []
+    for t in range(end + 1):
+        n = 0
+        for threads, st, up, hold, down in rows:
+            if t < st:
+                continue
+            dt = t - st
+            if dt < up:                       # ramping up
+                n += threads * dt / up if up else threads
+            elif dt < up + hold:              # plateau
+                n += threads
+            elif dt < up + hold + down:       # ramping down
+                n += threads * (1 - (dt - up - hold) / down) if down else 0
+        series.append(n)
+    return series
+
+
+def describe_concurrency(rows):
+    series = concurrency_timeline(rows)
+    peak = max(series)
+    duration = len(series) - 1
+    steady = sorted({round(v) for v in series if v > 0})
+    return (f"{len(rows)} waves, {duration}s, peak {peak:g} concurrent, "
+            f"levels {steady}")
+
+
+# ---------------------------------------------------------------- main
+
+# Each entry: plan marker -> (csv reader, xml builder, block name, anchor, describer)
+FAMILIES = [
+    (
+        "FreeFormArrivalsThreadGroup",
+        read_arrivals_profile,
+        build_schedule,
+        "Schedule",
+        r'(?=<stringProp name="LogFilename">)',
+        describe_arrivals,
+        "arrival rate",
+    ),
+    (
+        "kg.apc.jmeter.threads.UltimateThreadGroup",
+        read_concurrency_profile,
+        build_utg_data,
+        "ultimatethreadgroupdata",
+        r'(?=<elementProp name="ThreadGroup\.main_controller")',
+        describe_concurrency,
+        "concurrency",
+    ),
+]
 
 
 def main():
@@ -78,34 +205,34 @@ def main():
     plan_path, profile_path, out_path = sys.argv[1:4]
 
     plan = open(plan_path).read()
-    if "FreeFormArrivalsThreadGroup" not in plan:
-        raise SystemExit(
-            f"{plan_path}: no FreeFormArrivalsThreadGroup - this plan is not "
-            f"load-profile driven, nothing to inject"
+
+    for marker, reader, builder, block, anchor, describe, kind in FAMILIES:
+        if marker not in plan:
+            continue
+
+        rows = reader(profile_path)
+        # Non-greedy plus a lookahead anchor: inner </collectionProp> tags are not
+        # followed by the anchor, so the match extends to the correct outer close.
+        plan_out, n = re.subn(
+            r'<collectionProp name="' + block + r'">.*?</collectionProp>\s*' + anchor,
+            builder(rows),
+            plan,
+            count=1,
+            flags=re.S,
         )
+        if n != 1:
+            raise SystemExit(
+                f"{plan_path}: could not locate the {block} block to replace"
+            )
 
-    rows = read_profile(profile_path)
-    plan_out, n = re.subn(
-        r'<collectionProp name="Schedule">.*?</collectionProp>\s*(?=<stringProp name="LogFilename">)',
-        build_schedule(rows),
-        plan,
-        count=1,
-        flags=re.S,
-    )
-    if n != 1:
-        raise SystemExit(f"{plan_path}: could not locate the Schedule block to replace")
+        with open(out_path, "w") as fh:
+            fh.write(plan_out)
+        print(f"load profile applied ({kind}): {describe(rows)} -> {out_path}")
+        return
 
-    with open(out_path, "w") as fh:
-        fh.write(plan_out)
-
-    # Trapezoid: a step ramping start->end over dur averages (start+end)/2.
-    # Using start alone under-reports any ramped step.
-    total = round(sum((start + end) / 2 * dur for start, end, dur in rows))
-    duration = sum(dur for _, _, dur in rows)
-    peak = max(max(s, e) for s, e, _ in rows)
-    print(
-        f"load profile applied: {len(rows)} steps, {duration}s, "
-        f"peak {peak}/s, ~{total} expected samples -> {out_path}"
+    raise SystemExit(
+        f"{plan_path}: no FreeFormArrivalsThreadGroup or UltimateThreadGroup - "
+        f"this plan is not load-profile driven, nothing to inject"
     )
 
 

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/apply_load_profile.py
@@ -37,58 +37,10 @@ Two plan families are supported; the format is chosen from the plan, not a flag.
 Durations are in the unit set by the thread group's Unit property (S = seconds).
 """
 
-import csv
 import re
 import sys
 
-
-# ---------------------------------------------------------------- parsing
-
-def _rows(path, ncols, header_prefix):
-    """Read a CSV of exactly ncols integer columns, skipping a header if present."""
-    out = []
-    with open(path, newline="") as fh:
-        for lineno, parts in enumerate(csv.reader(fh), 1):
-            if not parts or not any(p.strip() for p in parts):
-                continue
-            if parts[0].strip().lower().startswith(header_prefix):
-                continue  # header
-            if len(parts) < ncols:
-                raise SystemExit(
-                    f"{path}:{lineno}: expected {ncols} columns, "
-                    f"got {len(parts)}: {parts!r}"
-                )
-            try:
-                out.append(tuple(int(p.strip()) for p in parts[:ncols]))
-            except ValueError:
-                raise SystemExit(
-                    f"{path}:{lineno}: non-integer value in {parts[:ncols]!r}"
-                )
-    if not out:
-        raise SystemExit(f"{path}: no usable rows found")
-    return out
-
-
-def read_arrivals_profile(path):
-    rows = _rows(path, 3, "startvalue")
-    for start, end, dur in rows:
-        if dur <= 0:
-            raise SystemExit(f"{path}: duration must be > 0, got {dur}")
-        if start < 0 or end < 0:
-            raise SystemExit(f"{path}: arrival rate must be >= 0, got {start},{end}")
-    return rows
-
-
-def read_concurrency_profile(path):
-    rows = _rows(path, 5, "threads")
-    for threads, start, startup, hold, shutdown in rows:
-        if threads <= 0:
-            raise SystemExit(f"{path}: Threads must be > 0, got {threads}")
-        if min(start, startup, hold, shutdown) < 0:
-            raise SystemExit(f"{path}: times must be >= 0 in row {rows!r}")
-        if hold <= 0:
-            raise SystemExit(f"{path}: HoldTime must be > 0, got {hold}")
-    return rows
+from load_profile import read_arrivals_profile, read_concurrency_profile
 
 
 # ---------------------------------------------------------------- emitting
@@ -210,7 +162,10 @@ def main():
         if marker not in plan:
             continue
 
-        rows = reader(profile_path)
+        try:
+            rows = reader(profile_path)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
         # Non-greedy plus a lookahead anchor: inner </collectionProp> tags are not
         # followed by the anchor, so the match extends to the correct outer close.
         plan_out, n = re.subn(

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
@@ -144,10 +144,15 @@ def markdown(run_id, s, meta):
           f"| Peak in flight | {s['peak_in_flight']} (at t={s['peak_at_s']} s) |",
           ""]
     lt = s["latency_ms"]
-    L += ["## Latency (ms)", "",
-          "| min | p50 | p90 | p95 | p99 | max | mean |", "|---|---|---|---|---|---|---|",
-          f"| {lt['min']} | {lt['p50']} | {lt['p90']} | {lt['p95']} | {lt['p99']} | {lt['max']} | {lt['mean']} |",
-          "", "_Percentiles are nearest-rank over successful samples._", ""]
+    if lt["min"] is None:
+        L += ["## Latency", "",
+              "_No successful samples — every query failed, so there are no latencies to report._",
+              ""]
+    else:
+        L += ["## Latency (ms)", "",
+              "| min | p50 | p90 | p95 | p99 | max | mean |", "|---|---|---|---|---|---|---|",
+              f"| {lt['min']} | {lt['p50']} | {lt['p90']} | {lt['p95']} | {lt['p99']} | {lt['max']} | {lt['mean']} |",
+              "", "_Percentiles are nearest-rank over successful samples._", ""]
 
     if "load_profile" in s:
         lp = s["load_profile"]

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
@@ -31,28 +31,55 @@ import statistics
 import sys
 
 
+# Exit code meaning "JMeter ran, but the run is not usable as a result".
+# Distinct from 1 (this script itself failed) so callers can tell them apart.
+EXIT_FAILED_RUN = 2
+
+
 def load(run_dir):
     path = os.path.join(run_dir, "JmeterResultFile.csv")
     if not os.path.exists(path):
-        raise SystemExit(f"{path}: not found")
+        # No results file at all: JMeter never got far enough to record a sample.
+        # This is a failed run, not a reporting glitch, so it must not exit 0.
+        print(f"  [FAIL] {path}: not found - no samples were recorded")
+        raise SystemExit(EXIT_FAILED_RUN)
     rows = list(csv.DictReader(open(path)))
     if not rows:
-        raise SystemExit(f"{path}: no samples")
+        print(f"  [FAIL] {path}: no samples - nothing executed")
+        raise SystemExit(EXIT_FAILED_RUN)
     return rows
 
 
 def read_profile(path):
-    rows = []
+    """Return (kind, rows) for either load-profile CSV format.
+
+    3 columns -> "arrivals"    StartValue,EndValue,Duration        (rate over time)
+    5 columns -> "concurrency" Threads,StartTime,StartupTime,
+                               HoldTime,ShutdownTime               (threads over time)
+
+    The two are checked differently: an arrivals profile is verified by counting
+    samples submitted, a concurrency profile by how many were in flight.
+    """
+    rows, width = [], None
     for parts in csv.reader(open(path, newline="")):
-        if not parts or not any(p.strip() for p in parts):
+        parts = [p.strip() for p in parts if p.strip() != ""]
+        if not parts:
             continue
-        if parts[0].strip().lower().startswith("startvalue"):
+        if parts[0].lower().startswith(("startvalue", "threads")):
+            continue  # header
+        if width is None:
+            width = len(parts)
+        try:
+            rows.append(tuple(int(p) for p in parts[:width]))
+        except ValueError:
             continue
-        rows.append(tuple(int(p.strip()) for p in parts[:3]))
-    return rows
+    if not rows:
+        return None, []
+    return ("concurrency" if width >= 5 else "arrivals"), rows
 
 
 def expected_per_second(steps):
+    """Arrivals profile: expected arrival rate at each second."""
     out = []
     for start, end, dur in steps:
         for i in range(dur):
@@ -60,7 +87,31 @@ def expected_per_second(steps):
     return out
 
 
-def analyse(rows, profile_steps=None):
+def expected_concurrency(waves):
+    """Concurrency profile: expected live threads at each second.
+
+    UltimateThreadGroup waves STACK - each row adds its threads on top of any
+    still running - and ramp linearly over StartupTime / ShutdownTime.
+    """
+    end = max(st + up + hold + down for _, st, up, hold, down in waves)
+    out = []
+    for t in range(end + 1):
+        n = 0.0
+        for threads, st, up, hold, down in waves:
+            if t < st:
+                continue
+            dt = t - st
+            if dt < up:
+                n += threads * dt / up
+            elif dt < up + hold:
+                n += threads
+            elif dt < up + hold + down:
+                n += threads * (1 - (dt - up - hold) / down)
+        out.append(n)
+    return out
+
+
+def analyse(rows, profile_steps=None, profile_kind="arrivals"):
     ok = [r for r in rows if r["success"] == "true"]
     lat = sorted(int(r["elapsed"]) for r in ok)
     starts = [int(r["timeStamp"]) for r in rows]
@@ -104,16 +155,48 @@ def analyse(rows, profile_steps=None):
         "in_flight_per_s": inflight,
     }
 
-    if profile_steps:
+    if profile_steps and profile_kind == "arrivals":
         exp = expected_per_second(profile_steps)
         delivered = sum(arr[: len(exp)])
         out["load_profile"] = {
+            "kind": "arrivals",
             "window_s": len(exp),
             "expected": sum(exp),
             "delivered": delivered,
             "delivered_pct": round(100 * delivered / sum(exp), 1) if sum(exp) else None,
             "arrivals_after_window": sum(arr[len(exp):]),
             "expected_per_s": exp,
+        }
+    elif profile_steps and profile_kind == "concurrency":
+        exp = expected_concurrency(profile_steps)
+        # Compare second by second, not on peak. At a wave boundary threads from
+        # the outgoing wave finish their in-flight query while the incoming wave
+        # starts, so peak in-flight briefly exceeds the profile by design - a
+        # peak-based check would flag a correct run. Only the seconds the profile
+        # actually asks for load are compared; the tail is drain.
+        # Tolerance is the looser of 2 threads or 20%. A fixed +-1 flags correct
+        # runs: during a 30s ramp to 20 threads, JMeter starts threads on its own
+        # discrete schedule while this model ramps linearly, so the two disagree
+        # by 2-3 threads mid-ramp even though the plateau is exact. Calibrated so
+        # a run against the wrong profile still scores ~14% against ~95% for a
+        # correct one.
+        overlap = min(len(exp), len(inflight))
+        tol = [max(2.0, 0.20 * exp[i]) for i in range(overlap)]
+        matched = sum(1 for i in range(overlap)
+                      if abs(inflight[i] - exp[i]) <= tol[i])
+        drift = [inflight[i] - exp[i] for i in range(overlap)]
+        out["load_profile"] = {
+            "kind": "concurrency",
+            "window_s": len(exp) - 1,
+            "compared_s": overlap,
+            "matched_s": matched,
+            "matched_pct": round(100 * matched / overlap, 1) if overlap else None,
+            "max_overshoot": round(max(drift), 1) if drift else None,
+            "max_shortfall": round(min(drift), 1) if drift else None,
+            "expected_peak": round(max(exp), 1),
+            "observed_peak": max(inflight),
+            "expected_levels": sorted({round(v) for v in exp if v > 0}),
+            "expected_per_s": [round(v, 2) for v in exp],
         }
 
     if out["failed"]:
@@ -154,15 +237,41 @@ def markdown(run_id, s, meta):
               f"| {lt['min']} | {lt['p50']} | {lt['p90']} | {lt['p95']} | {lt['p99']} | {lt['max']} | {lt['mean']} |",
               "", "_Percentiles are nearest-rank over successful samples._", ""]
 
-    if "load_profile" in s:
+    if s.get("load_profile", {}).get("kind") == "arrivals":
         lp = s["load_profile"]
         verdict = "OK" if lp["delivered_pct"] and lp["delivered_pct"] >= 95 else "SHORTFALL — raise MAX_CONCURRANCY"
-        L += ["## Load profile", "",
-              f"| window | expected | delivered | after window |", "|---|---|---|---|",
+        L += ["## Load profile — arrival rate", "",
+              "| window | expected | delivered | after window |", "|---|---|---|---|",
               f"| {lp['window_s']} s | {lp['expected']} | {lp['delivered']} ({lp['delivered_pct']}%) | {lp['arrivals_after_window']} |",
               "", f"**{verdict}**", ""]
         if lp["arrivals_after_window"]:
             L += ["> Arrivals after the profile window mean the schedule was not applied.", ""]
+
+    elif s.get("load_profile", {}).get("kind") == "concurrency":
+        lp = s["load_profile"]
+        pct = lp["matched_pct"]
+        if pct is None:
+            verdict = "nothing to compare against"
+        elif pct >= 90:
+            verdict = "OK — observed concurrency tracks the profile"
+        elif lp["max_shortfall"] < -1:
+            verdict = ("SHORTFALL — fewer threads in flight than requested; "
+                       "threads were idle between queries, or the schedule "
+                       "was not applied")
+        else:
+            verdict = ("MISMATCH — in-flight concurrency does not follow the "
+                       "profile; check the schedule was applied")
+        L += ["## Load profile — concurrency", "",
+              "| window | seconds matched | drift | expected peak | observed peak | levels |",
+              "|---|---|---|---|---|---|",
+              f"| {lp['window_s']} s | {lp['matched_s']}/{lp['compared_s']} ({pct}%) "
+              f"| {lp['max_shortfall']:+g} … {lp['max_overshoot']:+g} "
+              f"| {lp['expected_peak']} | {lp['observed_peak']} | {lp['expected_levels']} |",
+              "", f"**{verdict}**", "",
+              "> Matched = seconds where in-flight is within the looser of 2 threads "
+              "or 20% of the profile. In-flight is sampled at 1-second resolution "
+              "and a thread finishes its current query before stopping, so brief "
+              "drift during a ramp or at a wave boundary is expected, not a fault.", ""]
 
     L += ["## Queue build-up", "", "| t (s) | arrivals | in flight |", "|---|---|---|"]
     step = max(1, len(s["in_flight_per_s"]) // 20)
@@ -183,11 +292,17 @@ def main():
     ap.add_argument("run_dir")
     ap.add_argument("--profile")
     ap.add_argument("--meta", action="append", default=[])
+    ap.add_argument(
+        "--max-error-pct", type=float,
+        default=float(os.environ.get("MAX_ERROR_PCT", "5")),
+        help="exit %d if the error rate exceeds this (default 5, or $MAX_ERROR_PCT)"
+             % EXIT_FAILED_RUN)
     a = ap.parse_args()
 
     rows = load(a.run_dir)
-    steps = read_profile(a.profile) if a.profile and os.path.exists(a.profile) else None
-    s = analyse(rows, steps)
+    kind, steps = (read_profile(a.profile)
+                   if a.profile and os.path.exists(a.profile) else (None, None))
+    s = analyse(rows, steps, kind)
 
     meta = {}
     for kv in a.meta:
@@ -203,10 +318,24 @@ def main():
         fh.write(markdown(run_id, s, meta))
 
     warn = ""
-    if "load_profile" in s and s["load_profile"]["delivered_pct"] < 95:
-        warn = f"  [!] only {s['load_profile']['delivered_pct']}% of profile arrivals delivered"
+    lp = s.get("load_profile")
+    if lp and lp["kind"] == "arrivals" and (lp["delivered_pct"] or 0) < 95:
+        warn = f"  [!] only {lp['delivered_pct']}% of profile arrivals delivered"
+    elif lp and lp["kind"] == "concurrency" and (lp["matched_pct"] or 0) < 90:
+        warn = (f"  [!] in-flight matched the profile only "
+                f"{lp['matched_pct']}% of the time")
     print(f"  run report: {s['samples']} samples, {s['error_pct']}% errors, "
           f"{s['throughput_per_s']}/s, peak {s['peak_in_flight']} in flight{warn}")
+
+    # A run where the queries failed is not a result. Reporting success for it is
+    # worse than reporting nothing: the numbers look plausible and mean nothing.
+    if s["error_pct"] > a.max_error_pct:
+        print(f"  [FAIL] error rate {s['error_pct']}% exceeds the "
+              f"{a.max_error_pct}% threshold - this run is not a usable result")
+        for f in s.get("failure_messages", [])[:3]:
+            print(f"         {f['count']}x {f['message'][:120]}")
+        print(f"         raise the bar with MAX_ERROR_PCT=<pct> if errors are expected")
+        raise SystemExit(EXIT_FAILED_RUN)
 
 
 if __name__ == "__main__":

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
@@ -30,10 +30,21 @@ import os
 import statistics
 import sys
 
+from load_profile import (
+    expected_arrivals_per_second,
+    expected_concurrency_per_second,
+    read_profile,
+)
+
 
 # Exit code meaning "JMeter ran, but the run is not usable as a result".
 # Distinct from 1 (this script itself failed) so callers can tell them apart.
 EXIT_FAILED_RUN = 2
+
+# Infrastructure samplers may be written to the same JTL as query samplers.
+# They are useful in the raw file but must not affect query latency, throughput,
+# or error thresholds.
+CONTROL_SAMPLE_LABELS = {"Setup-Query-Loader-Trigger"}
 
 
 def load(run_dir):
@@ -43,72 +54,39 @@ def load(run_dir):
         # This is a failed run, not a reporting glitch, so it must not exit 0.
         print(f"  [FAIL] {path}: not found - no samples were recorded")
         raise SystemExit(EXIT_FAILED_RUN)
-    rows = list(csv.DictReader(open(path)))
+    raw_rows = list(csv.DictReader(open(path)))
+    rows = [row for row in raw_rows if row.get("label") not in CONTROL_SAMPLE_LABELS]
     if not rows:
         print(f"  [FAIL] {path}: no samples - nothing executed")
         raise SystemExit(EXIT_FAILED_RUN)
-    return rows
+    return rows, len(raw_rows), len(raw_rows) - len(rows)
 
 
-def read_profile(path):
-    """Return (kind, rows) for either load-profile CSV format.
+def peak_inflight_per_second(starts, ends, t0, buckets):
+    """Return peak interval overlap in each second.
 
-    3 columns -> "arrivals"    StartValue,EndValue,Duration        (rate over time)
-    5 columns -> "concurrency" Threads,StartTime,StartupTime,
-                               HoldTime,ShutdownTime               (threads over time)
-
-    The two are checked differently: an arrivals profile is verified by counting
-    samples submitted, a concurrency profile by how many were in flight.
+    Counting only arrivals minus completions at the end of a one-second bucket
+    reports zero for every query that starts and finishes within that bucket.
+    An event sweep preserves those short-lived queries and measures actual
+    query-in-flight concurrency rather than a bucket-end backlog snapshot.
     """
-    rows, width = [], None
-    for parts in csv.reader(open(path, newline="")):
-        parts = [p.strip() for p in parts if p.strip() != ""]
-        if not parts:
-            continue
-        if parts[0].lower().startswith(("startvalue", "threads")):
-            continue  # header
-        if width is None:
-            width = len(parts)
-        try:
-            rows.append(tuple(int(p) for p in parts[:width]))
-        except ValueError:
-            continue
-    if not rows:
-        return None, []
-    return ("concurrency" if width >= 5 else "arrivals"), rows
-
-
-def expected_per_second(steps):
-    """Arrivals profile: expected arrival rate at each second."""
-    out = []
-    for start, end, dur in steps:
-        for i in range(dur):
-            out.append(round(start if dur == 1 else start + (end - start) * i / (dur - 1)))
-    return out
-
-
-def expected_concurrency(waves):
-    """Concurrency profile: expected live threads at each second.
-
-    UltimateThreadGroup waves STACK - each row adds its threads on top of any
-    still running - and ramp linearly over StartupTime / ShutdownTime.
-    """
-    end = max(st + up + hold + down for _, st, up, hold, down in waves)
-    out = []
-    for t in range(end + 1):
-        n = 0.0
-        for threads, st, up, hold, down in waves:
-            if t < st:
-                continue
-            dt = t - st
-            if dt < up:
-                n += threads * dt / up
-            elif dt < up + hold:
-                n += threads
-            elif dt < up + hold + down:
-                n += threads * (1 - (dt - up - hold) / down)
-        out.append(n)
-    return out
+    events = {}
+    for start, end in zip(starts, ends):
+        events[start] = events.get(start, 0) + 1
+        events[end] = events.get(end, 0) - 1
+    ordered = sorted(events.items())
+    result = []
+    active = 0
+    position = 0
+    for bucket in range(buckets):
+        bucket_end = t0 + (bucket + 1) * 1000
+        peak = active
+        while position < len(ordered) and ordered[position][0] < bucket_end:
+            active += ordered[position][1]
+            peak = max(peak, active)
+            position += 1
+        result.append(peak)
+    return result
 
 
 def analyse(rows, profile_steps=None, profile_kind="arrivals"):
@@ -126,10 +104,7 @@ def analyse(rows, profile_steps=None, profile_kind="arrivals"):
     for s, e in zip(starts, ends):
         arr[(s - t0) // 1000] += 1
         comp[(e - t0) // 1000] += 1
-    inflight, running = [], 0
-    for a, c in zip(arr, comp):
-        running += a - c
-        inflight.append(running)
+    inflight = peak_inflight_per_second(starts, ends, t0, n)
 
     def p(q):
         return lat[math.ceil(q * len(lat)) - 1] if lat else None
@@ -156,7 +131,7 @@ def analyse(rows, profile_steps=None, profile_kind="arrivals"):
     }
 
     if profile_steps and profile_kind == "arrivals":
-        exp = expected_per_second(profile_steps)
+        exp = expected_arrivals_per_second(profile_steps)
         delivered = sum(arr[: len(exp)])
         out["load_profile"] = {
             "kind": "arrivals",
@@ -168,7 +143,7 @@ def analyse(rows, profile_steps=None, profile_kind="arrivals"):
             "expected_per_s": exp,
         }
     elif profile_steps and profile_kind == "concurrency":
-        exp = expected_concurrency(profile_steps)
+        exp = expected_concurrency_per_second(profile_steps)
         # Compare second by second, not on peak. At a wave boundary threads from
         # the outgoing wave finish their in-flight query while the incoming wave
         # starts, so peak in-flight briefly exceeds the profile by design - a
@@ -226,6 +201,9 @@ def markdown(run_id, s, meta):
           f"| Drain after last arrival | {s['drain_s']} s |",
           f"| Peak in flight | {s['peak_in_flight']} (at t={s['peak_at_s']} s) |",
           ""]
+    if s.get("ignored_control_samples"):
+        L += [f"_Excluded {s['ignored_control_samples']} framework control sample(s) "
+              f"from {s['raw_samples']} raw samples._", ""]
     lt = s["latency_ms"]
     if lt["min"] is None:
         L += ["## Latency", "",
@@ -299,10 +277,17 @@ def main():
              % EXIT_FAILED_RUN)
     a = ap.parse_args()
 
-    rows = load(a.run_dir)
-    kind, steps = (read_profile(a.profile)
-                   if a.profile and os.path.exists(a.profile) else (None, None))
+    rows, raw_samples, ignored_control_samples = load(a.run_dir)
+    try:
+        kind, steps = (read_profile(a.profile)
+                       if a.profile and os.path.exists(a.profile) else (None, None))
+    except ValueError as exc:
+        print(f"  [FAIL] invalid load profile: {exc}")
+        raise SystemExit(1) from exc
     s = analyse(rows, steps, kind)
+    s["raw_samples"] = raw_samples
+    s["query_samples"] = len(rows)
+    s["ignored_control_samples"] = ignored_control_samples
 
     meta = {}
     for kv in a.meta:

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/capture_run_report.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Capture a standard report for a completed run.
+
+Usage:
+    capture_run_report.py <run_dir> [--profile <load_profile.csv>] [--meta k=v ...]
+
+Writes two files into <run_dir>:
+
+    run_summary.json   machine-readable metrics (feeds Athena / comparison scripts)
+    run_report.md      human-readable summary
+
+Both are derived from JmeterResultFile.csv only, so they work for any engine the
+framework can drive. Called automatically by run_jmeter_tests_interactive.sh and
+run_test.sh after JMeter exits, so every run is self-describing without anyone
+remembering to run the analysis by hand.
+
+Metric definitions (stated so numbers are reproducible):
+  arrival     sample timeStamp            (JMeter records query START)
+  completion  timeStamp + elapsed
+  in-flight   arrivals - completions so far, at 1-second resolution
+  percentiles nearest-rank over successful samples
+"""
+
+import argparse
+import csv
+import json
+import math
+import os
+import statistics
+import sys
+
+
+def load(run_dir):
+    path = os.path.join(run_dir, "JmeterResultFile.csv")
+    if not os.path.exists(path):
+        raise SystemExit(f"{path}: not found")
+    rows = list(csv.DictReader(open(path)))
+    if not rows:
+        raise SystemExit(f"{path}: no samples")
+    return rows
+
+
+def read_profile(path):
+    rows = []
+    for parts in csv.reader(open(path, newline="")):
+        if not parts or not any(p.strip() for p in parts):
+            continue
+        if parts[0].strip().lower().startswith("startvalue"):
+            continue
+        rows.append(tuple(int(p.strip()) for p in parts[:3]))
+    return rows
+
+
+def expected_per_second(steps):
+    out = []
+    for start, end, dur in steps:
+        for i in range(dur):
+            out.append(round(start if dur == 1 else start + (end - start) * i / (dur - 1)))
+    return out
+
+
+def analyse(rows, profile_steps=None):
+    ok = [r for r in rows if r["success"] == "true"]
+    lat = sorted(int(r["elapsed"]) for r in ok)
+    starts = [int(r["timeStamp"]) for r in rows]
+    ends = [int(r["timeStamp"]) + int(r["elapsed"]) for r in rows]
+    t0, tend = min(starts), max(ends)
+    wall = (tend - t0) / 1000
+    arrival_window = (max(starts) - t0) / 1000
+
+    n = int(wall) + 2
+    arr = [0] * n
+    comp = [0] * n
+    for s, e in zip(starts, ends):
+        arr[(s - t0) // 1000] += 1
+        comp[(e - t0) // 1000] += 1
+    inflight, running = [], 0
+    for a, c in zip(arr, comp):
+        running += a - c
+        inflight.append(running)
+
+    def p(q):
+        return lat[math.ceil(q * len(lat)) - 1] if lat else None
+
+    out = {
+        "samples": len(rows),
+        "successful": len(ok),
+        "failed": len(rows) - len(ok),
+        "error_pct": round(100 * (len(rows) - len(ok)) / len(rows), 2),
+        "throughput_per_s": round(len(rows) / wall, 2) if wall else None,
+        "wall_clock_s": round(wall, 1),
+        "arrival_window_s": round(arrival_window, 1),
+        "drain_s": round(wall - arrival_window, 1),
+        "peak_in_flight": max(inflight),
+        "peak_at_s": inflight.index(max(inflight)),
+        "latency_ms": {
+            "min": lat[0] if lat else None,
+            "p50": p(0.50), "p90": p(0.90), "p95": p(0.95), "p99": p(0.99),
+            "max": lat[-1] if lat else None,
+            "mean": round(statistics.mean(lat)) if lat else None,
+        },
+        "arrivals_per_s": arr,
+        "in_flight_per_s": inflight,
+    }
+
+    if profile_steps:
+        exp = expected_per_second(profile_steps)
+        delivered = sum(arr[: len(exp)])
+        out["load_profile"] = {
+            "window_s": len(exp),
+            "expected": sum(exp),
+            "delivered": delivered,
+            "delivered_pct": round(100 * delivered / sum(exp), 1) if sum(exp) else None,
+            "arrivals_after_window": sum(arr[len(exp):]),
+            "expected_per_s": exp,
+        }
+
+    if out["failed"]:
+        msgs = {}
+        for r in rows:
+            if r["success"] != "true":
+                k = r["responseMessage"][:160]
+                msgs[k] = msgs.get(k, 0) + 1
+        out["failure_messages"] = sorted(
+            ({"count": v, "message": k} for k, v in msgs.items()),
+            key=lambda x: -x["count"],
+        )[:5]
+    return out
+
+
+def markdown(run_id, s, meta):
+    L = [f"# Run report — {run_id}", ""]
+    for k, v in meta.items():
+        L.append(f"**{k}:** {v}  ")
+    L += ["", "## Result", "",
+          "| | |", "|---|---|",
+          f"| Samples | {s['samples']} |",
+          f"| Errors | {s['failed']} ({s['error_pct']}%) |",
+          f"| Throughput | {s['throughput_per_s']} /s |",
+          f"| Wall clock | {s['wall_clock_s']} s |",
+          f"| Arrival window | {s['arrival_window_s']} s |",
+          f"| Drain after last arrival | {s['drain_s']} s |",
+          f"| Peak in flight | {s['peak_in_flight']} (at t={s['peak_at_s']} s) |",
+          ""]
+    lt = s["latency_ms"]
+    L += ["## Latency (ms)", "",
+          "| min | p50 | p90 | p95 | p99 | max | mean |", "|---|---|---|---|---|---|---|",
+          f"| {lt['min']} | {lt['p50']} | {lt['p90']} | {lt['p95']} | {lt['p99']} | {lt['max']} | {lt['mean']} |",
+          "", "_Percentiles are nearest-rank over successful samples._", ""]
+
+    if "load_profile" in s:
+        lp = s["load_profile"]
+        verdict = "OK" if lp["delivered_pct"] and lp["delivered_pct"] >= 95 else "SHORTFALL — raise MAX_CONCURRANCY"
+        L += ["## Load profile", "",
+              f"| window | expected | delivered | after window |", "|---|---|---|---|",
+              f"| {lp['window_s']} s | {lp['expected']} | {lp['delivered']} ({lp['delivered_pct']}%) | {lp['arrivals_after_window']} |",
+              "", f"**{verdict}**", ""]
+        if lp["arrivals_after_window"]:
+            L += ["> Arrivals after the profile window mean the schedule was not applied.", ""]
+
+    L += ["## Queue build-up", "", "| t (s) | arrivals | in flight |", "|---|---|---|"]
+    step = max(1, len(s["in_flight_per_s"]) // 20)
+    for i in range(0, len(s["in_flight_per_s"]), step):
+        L.append(f"| {i} | {s['arrivals_per_s'][i]} | {s['in_flight_per_s'][i]} |")
+    L.append("")
+
+    if "failure_messages" in s:
+        L += ["## Failures", ""]
+        for f in s["failure_messages"]:
+            L.append(f"- **{f['count']}x** `{f['message']}`")
+        L.append("")
+    return "\n".join(L)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_dir")
+    ap.add_argument("--profile")
+    ap.add_argument("--meta", action="append", default=[])
+    a = ap.parse_args()
+
+    rows = load(a.run_dir)
+    steps = read_profile(a.profile) if a.profile and os.path.exists(a.profile) else None
+    s = analyse(rows, steps)
+
+    meta = {}
+    for kv in a.meta:
+        if "=" in kv:
+            k, v = kv.split("=", 1)
+            meta[k] = v
+    s["meta"] = meta
+
+    run_id = os.path.basename(os.path.normpath(a.run_dir))
+    with open(os.path.join(a.run_dir, "run_summary.json"), "w") as fh:
+        json.dump(s, fh, indent=2)
+    with open(os.path.join(a.run_dir, "run_report.md"), "w") as fh:
+        fh.write(markdown(run_id, s, meta))
+
+    warn = ""
+    if "load_profile" in s and s["load_profile"]["delivered_pct"] < 95:
+        warn = f"  [!] only {s['load_profile']['delivered_pct']}% of profile arrivals delivered"
+    print(f"  run report: {s['samples']} samples, {s['error_pct']}% errors, "
+          f"{s['throughput_per_s']}/s, peak {s['peak_in_flight']} in flight{warn}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/fix_jmeter_jar_conflicts.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/fix_jmeter_jar_conflicts.sh
@@ -51,6 +51,7 @@ $DRY_RUN && echo -e "${YELLOW}DRY RUN - nothing will be moved${NC}"
 echo ""
 
 MOVED=0
+WARNINGS=0
 
 quarantine() {
     local f="$1" why="$2"
@@ -89,16 +90,37 @@ echo ""
 echo "2. Zero-byte or corrupt jars"
 FOUND_BAD=false
 while IFS= read -r j; do
-    FOUND_BAD=true
-    quarantine "$j" "zero bytes"
-done < <(find "$JMETER_DIR" -name "*.jar" -size 0 2>/dev/null)
+    if [ ! -s "$j" ]; then
+        FOUND_BAD=true
+        quarantine "$j" "zero bytes"
+    elif ! unzip -tq "$j" >/dev/null 2>&1; then
+        FOUND_BAD=true
+        quarantine "$j" "invalid zip archive"
+    fi
+done < <(find "$JMETER_DIR" -name "*.jar" -type f 2>/dev/null)
 $FOUND_BAD || echo -e "  ${GREEN}ok${NC} - none"
+echo ""
+
+# --- 3. Embedded dependency diagnostics ----------------------------------
+echo "3. Embedded logging / Netty dependencies"
+for j in "${E6_JARS[@]}"; do
+    [ -f "$j" ] || continue
+    if unzip -l "$j" 2>/dev/null | grep -q 'org/slf4j/impl/StaticLoggerBinder.class'; then
+        echo -e "  ${YELLOW}warning${NC} - $(basename "$j") embeds an SLF4J 1.x binding; JMeter may report multiple bindings"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+    if unzip -l "$j" 2>/dev/null | grep -q 'io/netty/'; then
+        echo -e "  ${YELLOW}warning${NC} - $(basename "$j") embeds Netty classes; JMeter class scanning may log ignored IllegalAccessError messages"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+done
+[ "$WARNINGS" -eq 0 ] && echo -e "  ${GREEN}ok${NC} - no embedded conflicts detected"
 echo ""
 
 # --- Result ---------------------------------------------------------------
 echo "=========================================="
 if [ "$MOVED" -eq 0 ]; then
-    echo -e "${GREEN}Classpath is clean - nothing to do.${NC}"
+    echo -e "${GREEN}No actionable duplicate or corrupt jars found.${NC}"
 else
     if $DRY_RUN; then
         echo -e "${YELLOW}${MOVED} jar(s) would be quarantined. Re-run without --dry-run.${NC}"
@@ -107,6 +129,7 @@ else
         echo "Restore with: mv ${QUARANTINE}/<jar> ${JMETER_DIR}/lib/ext/"
     fi
 fi
+[ "$WARNINGS" -gt 0 ] && echo -e "${YELLOW}${WARNINGS} non-actionable fat-jar warning(s); prefer a vendor-approved thin/shaded driver when available.${NC}"
 echo "=========================================="
 echo ""
 echo "e6 driver(s) now on the classpath:"

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/load_profile.py
@@ -1,0 +1,96 @@
+"""Shared parsing and expected-load models for JMeter load-profile CSVs."""
+
+import csv
+
+
+def _data_rows(path):
+    rows = []
+    with open(path, newline="") as fh:
+        for lineno, parts in enumerate(csv.reader(fh), 1):
+            parts = [part.strip() for part in parts]
+            if not parts or not any(parts):
+                continue
+            rows.append((lineno, parts))
+    return rows
+
+
+def _parse(path, width, header):
+    parsed = []
+    for lineno, parts in _data_rows(path):
+        if parts[0].lower() == header:
+            continue
+        if len(parts) != width:
+            raise ValueError(
+                f"{path}:{lineno}: expected exactly {width} columns, got {len(parts)}"
+            )
+        try:
+            parsed.append(tuple(int(part) for part in parts))
+        except ValueError as exc:
+            raise ValueError(f"{path}:{lineno}: profile values must be integers") from exc
+    if not parsed:
+        raise ValueError(f"{path}: no usable profile rows found")
+    return parsed
+
+
+def read_arrivals_profile(path):
+    rows = _parse(path, 3, "startvalue")
+    for start, end, duration in rows:
+        if start < 0 or end < 0:
+            raise ValueError(f"{path}: arrival rates must be >= 0")
+        if duration <= 0:
+            raise ValueError(f"{path}: Duration must be > 0")
+    return rows
+
+
+def read_concurrency_profile(path):
+    rows = _parse(path, 5, "threads")
+    for threads, start, startup, hold, shutdown in rows:
+        if threads <= 0:
+            raise ValueError(f"{path}: Threads must be > 0")
+        if min(start, startup, hold, shutdown) < 0:
+            raise ValueError(f"{path}: profile times must be >= 0")
+        if hold <= 0:
+            raise ValueError(f"{path}: HoldTime must be > 0")
+    return rows
+
+
+def read_profile(path):
+    rows = _data_rows(path)
+    if not rows:
+        raise ValueError(f"{path}: no usable profile rows found")
+    first = rows[0][1]
+    first_name = first[0].lower()
+    if first_name == "startvalue" or len(first) == 3:
+        return "arrivals", read_arrivals_profile(path)
+    if first_name == "threads" or len(first) == 5:
+        return "concurrency", read_concurrency_profile(path)
+    raise ValueError(f"{path}:{rows[0][0]}: expected a 3- or 5-column profile")
+
+
+def expected_arrivals_per_second(steps):
+    out = []
+    for start, end, duration in steps:
+        for index in range(duration):
+            value = start if duration == 1 else start + (end - start) * index / (duration - 1)
+            out.append(round(value))
+    return out
+
+
+def expected_concurrency_per_second(waves):
+    end = max(start + startup + hold + shutdown
+              for _, start, startup, hold, shutdown in waves)
+    out = []
+    for second in range(end + 1):
+        concurrent = 0.0
+        for threads, start, startup, hold, shutdown in waves:
+            if second < start:
+                continue
+            elapsed = second - start
+            if elapsed < startup:
+                concurrent += threads * elapsed / startup
+            elif elapsed < startup + hold:
+                concurrent += threads
+            elif elapsed < startup + hold + shutdown:
+                concurrent += threads * (1 - (elapsed - startup - hold) / shutdown)
+        out.append(concurrent)
+    return out

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/query_file_info.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/query_file_info.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Inspect a JMeter query CSV without interpreting or printing its SQL text."""
+
+import argparse
+import csv
+import hashlib
+
+
+def has_header(row):
+    names = {cell.strip().lower() for cell in row}
+    has_alias = bool(names & {"query_alias", "query_alias_name", "alias"})
+    has_query = bool(names & {"query", "query_string", "sql"})
+    return has_alias and has_query
+
+
+def inspect(path):
+    with open(path, newline="", encoding="utf-8-sig") as fh:
+        rows = list(csv.reader(fh))
+    nonempty = [row for row in rows if any(cell.strip() for cell in row)]
+    header = bool(nonempty and has_header(nonempty[0]))
+    with open(path, "rb") as fh:
+        digest = hashlib.sha256(fh.read()).hexdigest()
+    return {
+        "rows": max(0, len(nonempty) - int(header)),
+        "header": header,
+        "sha256": digest,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path")
+    parser.add_argument("--field", choices=("rows", "header", "sha256"))
+    args = parser.parse_args()
+    info = inspect(args.path)
+    if args.field:
+        value = info[args.field]
+        print(str(value).lower() if isinstance(value, bool) else value)
+    else:
+        for key, value in info.items():
+            print(f"{key}={str(value).lower() if isinstance(value, bool) else value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_all_concurrency.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_all_concurrency.sh
@@ -276,8 +276,29 @@ for concurrency in "${CONCURRENCY_LEVELS[@]}"; do
     QUERY_FILE_PATH="$QUERY_FILE"
     [ -f "$QUERY_FILE_PATH" ] || QUERY_FILE_PATH="data_files/$QUERY_FILE"
 
-    # Concurrency comes from the sweep, not from the properties file, so the
-    # per-level properties file only needs to exist for its other settings.
+    # run_test.sh takes env vars, not a properties file, so load the template's
+    # properties file here and export its settings. Without this the sweep would
+    # silently fall back to run_test.sh defaults - MAX_CONCURRANCY 900 instead of
+    # the file's value, for example - while still printing the file name above as
+    # though it were in effect.
+    TEST_PROPS_PATH="$TEST_PROPS"
+    [ -f "$TEST_PROPS_PATH" ] || TEST_PROPS_PATH="test_properties/$TEST_PROPS"
+    if [ -f "$TEST_PROPS_PATH" ]; then
+        while IFS='=' read -r _k _v; do
+            [[ "$_k" =~ ^[[:space:]]*# ]] && continue
+            _k=$(echo "$_k" | xargs)
+            # only settings run_test.sh acts on; skip log_level.* and JMETER_HOME
+            case "$_k" in
+                HOLD_PERIOD|RAMP_UP_TIME|RAMP_UP_STEPS|QPS|QPM|RANDOM_ORDER|RECYCLE_ON_EOF|\
+                QUERY_TIMEOUT|LIMIT_RESULTSET|MAX_CONCURRANCY|LOAD_PROFILE|COPY_TO_S3|S3_REPORT_PATH)
+                    export "$_k=$(echo "$_v" | xargs)" ;;
+            esac
+        done < "$TEST_PROPS_PATH"
+    else
+        echo -e "${YELLOW}  Warning: properties file not found: $TEST_PROPS_PATH — using run_test.sh defaults${NC}"
+    fi
+
+    # Concurrency comes from the sweep, overriding whatever the properties file says.
     if CONNECTION_FILE="connection_properties/$CONNECTION_FILE" \
        TEST_PLAN="$TEST_PLAN_PATH" \
        QUERY_FILE="$QUERY_FILE_PATH" \

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_all_concurrency.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_all_concurrency.sh
@@ -12,6 +12,7 @@
 # Concurrency levels: 1, 2, 4, 8, 12, 16
 
 set -e
+set -o pipefail
 
 # Check arguments
 if [ $# -lt 3 ]; then

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_all_concurrency.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_all_concurrency.sh
@@ -264,18 +264,26 @@ for concurrency in "${CONCURRENCY_LEVELS[@]}"; do
     echo "Log file: $LOG_FILE"
     echo ""
 
-    # Create temporary resolved test input file
-    TEMP_TEST_INPUT="/tmp/test_input_resolved_${concurrency}.txt"
-    cat > "$TEMP_TEST_INPUT" << EOF
-$METADATA_FILE
-$TEST_PLAN
-$TEST_PROPS
-$CONNECTION_FILE
-$QUERY_FILE
-EOF
+    # Drive the non-interactive runner. This previously piped the five resolved
+    # filenames into run_jmeter_tests_interactive.sh, which stopped working when
+    # that script moved from filename prompts to numbered menus - it rejected
+    # every line ("Invalid choice") and the sweep could not run. run_test.sh takes
+    # explicit variables, so there are no menu indices to keep in sync.
+    #
+    # Values from the template are bare filenames; run_test.sh wants paths.
+    TEST_PLAN_PATH="$TEST_PLAN"
+    [ -f "$TEST_PLAN_PATH" ] || TEST_PLAN_PATH="Test-Plans/$TEST_PLAN"
+    QUERY_FILE_PATH="$QUERY_FILE"
+    [ -f "$QUERY_FILE_PATH" ] || QUERY_FILE_PATH="data_files/$QUERY_FILE"
 
-    # Run test with resolved input
-    if ./run_jmeter_tests_interactive.sh < "$TEMP_TEST_INPUT" 2>&1 | tee "$LOG_FILE"; then
+    # Concurrency comes from the sweep, not from the properties file, so the
+    # per-level properties file only needs to exist for its other settings.
+    if CONNECTION_FILE="connection_properties/$CONNECTION_FILE" \
+       TEST_PLAN="$TEST_PLAN_PATH" \
+       QUERY_FILE="$QUERY_FILE_PATH" \
+       METADATA_FILE="$METADATA_FULL_PATH" \
+       CONCURRENT_QUERY_COUNT="$concurrency" \
+       ./run_test.sh 2>&1 | tee "$LOG_FILE"; then
         echo -e "${GREEN}✓ Test completed: Concurrency ${concurrency}${NC}"
     else
         echo -e "${YELLOW}⚠ Test failed or interrupted: Concurrency ${concurrency}${NC}"
@@ -286,9 +294,6 @@ EOF
             exit 1
         fi
     fi
-
-    # Cleanup temporary file
-    rm -f "$TEMP_TEST_INPUT"
 
     # Wait between tests
     # Get last element in a shell-compatible way

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_premerge_checks.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_premerge_checks.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Dependency-light checks that must pass before merging framework changes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+python3 -m unittest discover -s utilities/tests -v
+python3 -m compileall -q utilities
+
+for script in ./*.sh utilities/*.sh utilities/athena/*.sh utilities/athena/setup/*.sh; do
+    bash -n "$script"
+done
+
+if command -v xmllint >/dev/null 2>&1; then
+    for plan in Test-Plans/*.jmx; do
+        xmllint --noout "$plan"
+    done
+else
+    python3 - <<'PY'
+import glob
+import xml.etree.ElementTree as ET
+for path in glob.glob("Test-Plans/*.jmx"):
+    ET.parse(path)
+PY
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+python3 utilities/apply_load_profile.py \
+    Test-Plans/Test-Plan-Fire-QPS-with-load-profile.jmx \
+    test_properties/load_profile.csv "$tmp/arrivals.jmx"
+python3 utilities/apply_load_profile.py \
+    Test-Plans/Test-Plan-Maintain-variable-concurrency-with-load-profile.jmx \
+    test_properties/utg_load_profile.csv "$tmp/concurrency.jmx"
+
+echo "All JMeter pre-merge checks passed."

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_smoke_suite.sh
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/run_smoke_suite.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Bounded JDBC smoke suite. This generates real query load.
+# Usage: utilities/run_smoke_suite.sh <connection.properties> <queries.csv>
+set -uo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <connection.properties> <queries.csv>"
+    exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+CONNECTION_FILE="$1"
+QUERY_FILE="$2"
+[ -f "$CONNECTION_FILE" ] || { echo "Connection file not found: $CONNECTION_FILE"; exit 1; }
+[ -f "$QUERY_FILE" ] || { echo "Query file not found: $QUERY_FILE"; exit 1; }
+
+SUITE_ID=$(python3 -c 'from datetime import datetime; print(datetime.now().strftime("%Y%m%d-%H%M%S-%f"))')
+SUITE_REPORT_PATH="${SMOKE_REPORT_PATH:-reports/smoke-${SUITE_ID}}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+printf '%s\n' 'StartValue,EndValue,Duration' '1,1,8' > "$tmp/arrivals.csv"
+printf '%s\n' 'Threads,StartTime,StartupTime,HoldTime,ShutdownTime' '2,0,0,10,0' > "$tmp/concurrency.csv"
+
+failures=0
+run_case() {
+    name="$1"; plan="$2"; shift 2
+    echo "===== smoke: ${name} ====="
+    env CONNECTION_FILE="$CONNECTION_FILE" TEST_PLAN="Test-Plans/$plan" \
+        QUERY_FILE="$QUERY_FILE" REPORT_PATH="$SUITE_REPORT_PATH" \
+        GENERATE_DASHBOARD=false COPY_TO_S3=false MAX_ERROR_PCT="${MAX_ERROR_PCT:-5}" \
+        RUN_TYPE="smoke_${name}" "$@" ./run_test.sh || failures=$((failures + 1))
+}
+
+run_case run_once Test-Plan-Run-Once-static-concurrency.jmx \
+    CONCURRENT_QUERY_COUNT=1 RECYCLE_ON_EOF=false
+run_case static_c2 Test-Plan-Maintain-static-concurrency.jmx \
+    CONCURRENT_QUERY_COUNT=2 HOLD_PERIOD=10 RECYCLE_ON_EOF=true
+run_case qps_1 Test-Plan-Constant-QPS-On-Arrivals-JSR-Optimized.jmx \
+    QPS=1 HOLD_PERIOD=8 MAX_CONCURRANCY=10 RECYCLE_ON_EOF=true
+run_case arrivals Test-Plan-Fire-QPS-with-load-profile.jmx \
+    LOAD_PROFILE="$tmp/arrivals.csv" HOLD_PERIOD=8 MAX_CONCURRANCY=10 RECYCLE_ON_EOF=true
+run_case variable_c2 Test-Plan-Maintain-variable-concurrency-with-load-profile.jmx \
+    LOAD_PROFILE="$tmp/concurrency.csv" RECYCLE_ON_EOF=true
+
+echo "Smoke reports: ${SUITE_REPORT_PATH}"
+if [ "$failures" -ne 0 ]; then
+    echo "Smoke suite failed: ${failures}/5 plans failed."
+    exit 1
+fi
+echo "Smoke suite passed: 5/5 plans."

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/tests/test_load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/tests/test_load_profile.py
@@ -1,0 +1,102 @@
+import csv
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+UTILITIES = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(UTILITIES))
+
+import capture_run_report
+import load_profile
+import query_file_info
+
+
+class LoadProfileParsingTests(unittest.TestCase):
+    def write(self, text):
+        handle = tempfile.NamedTemporaryFile("w", delete=False, newline="")
+        self.addCleanup(lambda: os.path.exists(handle.name) and os.unlink(handle.name))
+        handle.write(text)
+        handle.close()
+        return handle.name
+
+    def test_arrivals_profile(self):
+        path = self.write("StartValue,EndValue,Duration\n1,3,3\n")
+        kind, rows = load_profile.read_profile(path)
+        self.assertEqual(kind, "arrivals")
+        self.assertEqual(rows, [(1, 3, 3)])
+        self.assertEqual(load_profile.expected_arrivals_per_second(rows), [1, 2, 3])
+
+    def test_concurrency_profile(self):
+        path = self.write(
+            "Threads,StartTime,StartupTime,HoldTime,ShutdownTime\n4,0,0,2,0\n"
+        )
+        kind, rows = load_profile.read_profile(path)
+        self.assertEqual(kind, "concurrency")
+        self.assertEqual(load_profile.expected_concurrency_per_second(rows), [4.0, 4.0, 0.0])
+
+    def test_rejects_extra_columns(self):
+        path = self.write("StartValue,EndValue,Duration\n1,2,3,4\n")
+        with self.assertRaisesRegex(ValueError, "exactly 3 columns"):
+            load_profile.read_profile(path)
+
+    def test_rejects_invalid_values(self):
+        path = self.write("Threads,StartTime,StartupTime,HoldTime,ShutdownTime\n0,0,0,2,0\n")
+        with self.assertRaisesRegex(ValueError, "Threads must be > 0"):
+            load_profile.read_profile(path)
+
+    def test_query_file_info_excludes_recognized_header(self):
+        path = self.write('Query_Alias,Query\nq1,"select 1"\nq2,"select 2"\n')
+        info = query_file_info.inspect(path)
+        self.assertEqual(info["rows"], 2)
+        self.assertTrue(info["header"])
+        self.assertEqual(len(info["sha256"]), 64)
+
+    def test_query_file_info_keeps_headerless_first_query(self):
+        path = self.write('q1,"select 1"\nq2,"select 2"\n')
+        info = query_file_info.inspect(path)
+        self.assertEqual(info["rows"], 2)
+        self.assertFalse(info["header"])
+
+
+class ReportMetricTests(unittest.TestCase):
+    @staticmethod
+    def row(start, elapsed, success="true"):
+        return {
+            "timeStamp": str(start),
+            "elapsed": str(elapsed),
+            "success": success,
+            "responseMessage": "OK" if success == "true" else "failed",
+        }
+
+    def test_subsecond_queries_contribute_to_peak_inflight(self):
+        rows = [self.row(1000, 200), self.row(1050, 200)]
+        report = capture_run_report.analyse(rows)
+        self.assertEqual(report["peak_in_flight"], 2)
+
+    def test_boundary_completion_does_not_overlap_next_start(self):
+        rows = [self.row(1000, 1000), self.row(2000, 100)]
+        report = capture_run_report.analyse(rows)
+        self.assertEqual(report["peak_in_flight"], 1)
+
+    def test_error_metrics(self):
+        rows = [self.row(1000, 100), self.row(1100, 100, "false")]
+        report = capture_run_report.analyse(rows)
+        self.assertEqual(report["failed"], 1)
+        self.assertEqual(report["error_pct"], 50.0)
+
+    def test_control_sampler_can_be_excluded_from_query_metrics(self):
+        rows = [self.row(1000, 0), self.row(1000, 250)]
+        rows[0]["label"] = "Setup-Query-Loader-Trigger"
+        rows[1]["label"] = "Q1"
+        query_rows = [row for row in rows
+                      if row.get("label") not in capture_run_report.CONTROL_SAMPLE_LABELS]
+        report = capture_run_report.analyse(query_rows)
+        self.assertEqual(report["samples"], 1)
+        self.assertEqual(report["latency_ms"]["min"], 250)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/tests/test_runner.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/tests/test_runner.py
@@ -1,0 +1,90 @@
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+FAKE_JMETER = r'''#!/bin/bash
+result=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-l" ]; then
+        shift
+        result="$1"
+    fi
+    shift
+done
+if [ "${FAKE_JMETER_RC:-0}" -eq 0 ]; then
+    mkdir -p "$(dirname "$result")"
+    printf '%s\n' \
+      'timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,failureMessage,bytes,sentBytes,grpThreads,allThreads,URL,Latency,IdleTime,Connect' \
+      '1000,100,q1,200,OK,t,text,true,,1,1,1,1,,100,0,1' > "$result"
+fi
+exit "${FAKE_JMETER_RC:-0}"
+'''
+
+
+class RunnerIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        root = Path(self.temp.name)
+        self.jmeter_home = root / "jmeter"
+        (self.jmeter_home / "bin").mkdir(parents=True)
+        executable = self.jmeter_home / "bin" / "jmeter"
+        executable.write_text(FAKE_JMETER)
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+        self.connection = root / "connection.properties"
+        self.connection.write_text("CONNECTION_STRING=jdbc:test\n")
+        self.plan = root / "plain.jmx"
+        self.plan.write_text("<jmeterTestPlan/>\n")
+        self.queries = root / "queries.csv"
+        self.queries.write_text('query_alias,query_string\nq1,"select 1"\n')
+        self.reports = root / "reports"
+
+    def run_runner(self, **overrides):
+        env = os.environ.copy()
+        env.update({
+            "CONNECTION_FILE": str(self.connection),
+            "TEST_PLAN": str(self.plan),
+            "QUERY_FILE": str(self.queries),
+            "JMETER_HOME": str(self.jmeter_home),
+            "REPORT_PATH": str(self.reports),
+            "GENERATE_DASHBOARD": "false",
+            "COPY_TO_S3": "false",
+            "CONCURRENT_QUERY_COUNT": "4",
+        })
+        env.update(overrides)
+        return subprocess.run(
+            [str(ROOT / "run_test.sh")], cwd=ROOT, env=env,
+            text=True, capture_output=True, timeout=20,
+        )
+
+    def test_success_infers_partition_compatible_run_type(self):
+        completed = self.run_runner()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("queries.csv (1 queries)", completed.stdout)
+        self.assertIn("Dashboard: disabled", completed.stdout)
+        run_dir = next(self.reports.iterdir())
+        summary = json.loads((run_dir / "run_summary.json").read_text())
+        self.assertEqual(summary["meta"]["run_type"], "concurrency_4")
+        self.assertEqual(summary["raw_samples"], 1)
+        self.assertEqual(summary["query_samples"], 1)
+        self.assertEqual(summary["ignored_control_samples"], 0)
+        self.assertEqual(summary["meta"]["requested_concurrency"], "4")
+        self.assertEqual(len(summary["meta"]["query_sha256"]), 64)
+
+    def test_jmeter_failure_is_finalized_and_propagated(self):
+        completed = self.run_runner(FAKE_JMETER_RC="7")
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("JMeter exited with status 7", completed.stdout)
+        self.assertIn("Test FAILED", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/verify_load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/verify_load_profile.py
@@ -18,32 +18,11 @@ MAX_CONCURRANCY (it feeds ConcurrencyLimit).
 """
 
 import collections
-import csv
 import sys
 
+import csv
 
-def read_profile(path):
-    rows = []
-    with open(path, newline="") as fh:
-        for parts in csv.reader(fh):
-            if not parts or not any(p.strip() for p in parts):
-                continue
-            if parts[0].strip().lower().startswith("startvalue"):
-                continue
-            start, end, dur = (int(p.strip()) for p in parts[:3])
-            rows.append((start, end, dur))
-    return rows
-
-
-def expected_per_second(rows):
-    """Expand profile steps into a per-second expected rate, interpolating ramps."""
-    out = []
-    for start, end, dur in rows:
-        for i in range(dur):
-            # linear interpolation across the step; flat when start == end
-            rate = start if dur == 1 else start + (end - start) * i / (dur - 1)
-            out.append(round(rate))
-    return out
+from load_profile import expected_arrivals_per_second, read_profile
 
 
 def main():
@@ -58,7 +37,13 @@ def main():
     t0 = min(stamps)
     actual = collections.Counter((t - t0) // 1000 for t in stamps)
 
-    expected = expected_per_second(read_profile(profile_path))
+    try:
+        kind, profile = read_profile(profile_path)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if kind != "arrivals":
+        raise SystemExit(f"{profile_path}: expected an arrival-rate profile")
+    expected = expected_arrivals_per_second(profile)
 
     print(f"{'sec':>4} | {'expected':>8} | {'actual':>6} |")
     print("-" * 30)

--- a/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/verify_load_profile.py
+++ b/jmeter_benchmarks/jmeter-jdbc-test-framework/utilities/verify_load_profile.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Verify that queries were fired at the rate the load profile asked for.
+
+Usage:
+    verify_load_profile.py <JmeterResultFile.csv> <profile.csv>
+
+Compares the per-second arrival rate actually achieved against the profile.
+The JMeter `timeStamp` column is each sample's START time, so bucketing it by
+second reconstructs the arrival curve independently of how long queries took to
+complete - which is what you want, since a saturated cluster stretches
+completions long past the profile window without changing arrivals.
+
+A healthy run shows actual tracking expected within a sample or two per second,
+and no arrivals after the profile window. Persistent shortfall means the
+arrivals thread group could not start threads fast enough - raise
+MAX_CONCURRANCY (it feeds ConcurrencyLimit).
+"""
+
+import collections
+import csv
+import sys
+
+
+def read_profile(path):
+    rows = []
+    with open(path, newline="") as fh:
+        for parts in csv.reader(fh):
+            if not parts or not any(p.strip() for p in parts):
+                continue
+            if parts[0].strip().lower().startswith("startvalue"):
+                continue
+            start, end, dur = (int(p.strip()) for p in parts[:3])
+            rows.append((start, end, dur))
+    return rows
+
+
+def expected_per_second(rows):
+    """Expand profile steps into a per-second expected rate, interpolating ramps."""
+    out = []
+    for start, end, dur in rows:
+        for i in range(dur):
+            # linear interpolation across the step; flat when start == end
+            rate = start if dur == 1 else start + (end - start) * i / (dur - 1)
+            out.append(round(rate))
+    return out
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise SystemExit(__doc__.strip())
+    results_path, profile_path = sys.argv[1:3]
+
+    rows = list(csv.DictReader(open(results_path)))
+    if not rows:
+        raise SystemExit(f"{results_path}: no samples")
+    stamps = [int(r["timeStamp"]) for r in rows]
+    t0 = min(stamps)
+    actual = collections.Counter((t - t0) // 1000 for t in stamps)
+
+    expected = expected_per_second(read_profile(profile_path))
+
+    print(f"{'sec':>4} | {'expected':>8} | {'actual':>6} |")
+    print("-" * 30)
+    tot_e = tot_a = 0
+    for sec, exp in enumerate(expected):
+        act = actual.get(sec, 0)
+        tot_e += exp
+        tot_a += act
+        flag = "" if abs(act - exp) <= max(1, exp * 0.1) else "  <-- off"
+        print(f"{sec:>4} | {exp:>8} | {act:>6} | {'#' * act}{flag}")
+
+    window = len(expected)
+    late = sum(v for k, v in actual.items() if k >= window)
+    pct = (tot_a / tot_e * 100) if tot_e else 0
+
+    print()
+    print(f"profile window : {window}s")
+    print(f"expected       : {tot_e}")
+    print(f"actual         : {tot_a}  ({pct:.1f}%)")
+    print(f"after window   : {late}")
+    print(f"total samples  : {len(rows)}")
+    if pct < 95:
+        print("\nShortfall >5%: arrivals were dropped. Raise MAX_CONCURRANCY.")
+    if late:
+        print("\nArrivals after the profile window - the schedule may not have applied.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pov/README.md
+++ b/pov/README.md
@@ -1,179 +1,85 @@
-# Benchmark POV Tool <!-- omit in toc -->
-​
-The Benchmark POV Tool simplifies the complex process of benchmarking different compute engines. Follow these steps to get it up and running:
-​
-- [Prerequisites](#prerequisites)
-  - [Install Docker \& docker-compose](#install-docker--docker-compose)
-- [1. Install \& configure the Benchmark POV Tool using Docker](#1-install--configure-the-benchmark-pov-tool-using-docker)
-  - [1.1 Configure Environment Variables (optional)](#11-configure-environment-variables-optional)
-  - [1.2 Configure volume for persistence (option)](#12-configure-volume-for-persistence-option)
-  - [1.3 Deploy the Benchmark POV Tool in a local environment](#13-deploy-the-benchmark-pov-tool-in-a-local-environment)
-- [2. Configure the engines (e6data vs a target engine)](#2-configure-the-engines-e6data-vs-a-target-engine)
-  - [2.1 Set up an e6data cluster](#21-set-up-an-e6data-cluster)
-  - [2.2 Set up a Databricks cluster](#22-set-up-a-databricks-cluster)
-- [3. Add the engines to the Benchmark POV Tool](#3-add-the-engines-to-the-benchmark-pov-tool)
-  - [3.1 Login to the Benchmark POV Tool Admin Console](#31-login-to-the-benchmark-pov-tool-admin-console)
-  - [3.2 Create an user account](#32-create-an-user-account)
-  - [3.3 Add engines to the Benchmark POV Tool](#33-add-engines-to-the-benchmark-pov-tool)
-- [4. Upload queries and run benchmarks](#4-upload-queries-and-run-benchmarks)
-- [5. Uninstall the Benchmark POV Tool](#5-uninstall-the-benchmark-pov-tool)
-  - [5.1 Remove the Benchmark POV Tool but retain settings \& benchmarks for future use](#51-remove-the-benchmark-pov-tool-but-retain-settings--benchmarks-for-future-use)
-  - [5.2 Remove the Benchmark POV Tool and delete all associated settings \& data.](#52-remove-the-benchmark-pov-tool-and-delete-all-associated-settings--data)
-​
-​
+# Benchmark POV Tool
+
+The Benchmark POV Tool is a browser UI for comparing e6data and Databricks query workloads. This directory contains only its deployment wrapper: Docker Compose starts prebuilt frontend and backend images plus MySQL; the application source is not part of this repository.
+
 ## Prerequisites
-- **Docker**
-    - Docker Engine v1.13.0+
-    - docker-compose v1.10.0+
-- **e6data**
-    - Generate an e6data Personal Access Token
-	- An active e6data cluster & connection details
-	- Allowlist IP of the Benchmark POV Tool
-- **Databricks**
-    - Generate a Databricks Personal Access Token
-	- An active Databricks cluster & connection details
-​
-### Install Docker & docker-compose
-- [Docker Engine installation instructions](https://docs.docker.com/engine/install/)
-- [docker-compose installation instructions](https://docs.docker.com/compose/install/)
-​
-## 1. Install & configure the Benchmark POV Tool using Docker
-1. Download a copy of the e6-public-benchmarks repo from GitHub: [link](https://github.com/e6x-labs/e6-public-benchmarks)
-2. Extract the contents to the directory where it will be installed.
-3. Navigate to the `/pov` folder
-​
-### 1.1 Configure Environment Variables (optional)
-- If you are installing the tool in a local environment, no edits to the `env` file are required.
-- To install in remote server, please replace `REACT_APP_API_DOMAIN` with the domain/IP of the server.
-​
-```docker
-#BACKEND PARAMS
-MYSQL_WRITER_HOST='dbserver'
-DJANGO_SUPERUSER_USERNAME='admin'
-DJANGO_SUPERUSER_PASSWORD='password'
-DJANGO_SUPERUSER_EMAIL='admin@admin.com'
-SERVER='DEV'
-PERSISTENCE_VOLUME='pov_tool_data'
-​
-# REACT APP PARAMS
-REACT_APP_API_DOMAIN='http://localhost:3001/api/'
-​
-# MYSQL PARAMS
-MYSQL_ROOT_PASSWORD='password'
+
+- Docker Engine with Docker Compose support
+- An active e6data cluster, catalog, user, and personal access token
+- An active Databricks compute resource, server hostname, HTTP path, and personal access token
+- Network allowlisting that lets the containers reach both engines
+
+Use comparable datasets and compute sizes on both engines if the results will be used for a performance comparison.
+
+## Configure
+
+The tracked `.env` file is a local demonstration configuration. Before starting, change at least the Django administrator password and MySQL root password. Do not expose the service publicly with the defaults.
+
+For a remote host, set `REACT_APP_API_DOMAIN` to the externally reachable backend URL, including `/api/`:
+
+```dotenv
+DJANGO_SUPERUSER_USERNAME=admin
+DJANGO_SUPERUSER_PASSWORD=<strong-password>
+DJANGO_SUPERUSER_EMAIL=admin@example.com
+MYSQL_ROOT_PASSWORD=<strong-password>
+PERSISTENCE_VOLUME=pov_tool_data
+REACT_APP_API_DOMAIN=https://benchmark.example.com/api/
 ```
-​
-### 1.2 Configure volume for persistence (option)
-​
-To preserve the Benchmark POV Tool's state (configuration settings, benchmark history, etc.), a volume named `pov_tool_storage` will be created.
-​
-To change the name of the volume edit the `PERSISTENCE_VOLUME` variable in the `.env` file:
-​
-```docker
-PERSISTENCE_VOLUME='pov_tool_data'
+
+The named Docker volume in `PERSISTENCE_VOLUME` retains MySQL data across container recreation.
+
+## Start
+
+Run from this directory:
+
+```bash
+docker compose up -d
+docker compose ps
 ```
-​
-### 1.3 Deploy the Benchmark POV Tool in a local environment
-​
-**Run the docker-compose command**
-​
-> This commands needs to be run from the same directory as the docker-compose.yaml file
-​
-```console
-docker-compose up -d
+
+On a local deployment:
+
+- Frontend: `http://localhost:3000/login/`
+- Django administration: `http://localhost:3001/api/`
+
+The images are pinned in [docker-compose.yaml](docker-compose.yaml). The first start requires access to their Google Artifact Registry location and may take time while Docker pulls them.
+
+## Configure the application
+
+1. Sign in to the Django administration page with the `DJANGO_SUPERUSER_*` values.
+2. Create a normal application user under `Home > User > Users`; use this account for the frontend.
+3. Under `Benchmarks > Benchmark_ips`, add the e6data and Databricks connection details. Use the same logical database/dataset for both sides.
+4. Sign in to the frontend and select **Create Benchmark**.
+5. Enter the benchmark name, engine pair, hourly costs, and sequential/concurrent settings.
+6. Upload the query CSV using the sample offered by the UI, then run the benchmark.
+7. Review per-query time and estimated cost, and download the detailed report if needed.
+
+Treat downloaded reports as sensitive: they can contain SQL text, connection-related errors, and workload metadata.
+
+## Operate and stop
+
+Inspect logs with:
+
+```bash
+docker compose logs -f backend frontend dbserver
 ```
-​
-## 2. Configure the engines (e6data vs a target engine)
-​
-### 2.1 Set up an e6data cluster
-​
-1. Login to your e6data console. 
-2. Select the workspace in which you wish to spin up the cluster.
-3. [Create a catalog](https://docs.e6data.com/docs/catalogs) (if you haven’t created one already).
-4. [Spin up a cluster](https://docs.e6data.com/docs/cluster) with a configuration equivalent to the engine you’ll be benchmarking against.
-5. While waiting for the cluster spin up, [allow-list](https://docs.e6data.com/docs/access-control/ip-allowlisting) the IP you’ll be hosting the Benchmark POV tool on.
-	- If you are running the Benchmark POV tool locally, use this [WhatIsMyIP.com](https://whatismyipaddress.com) to find your IP.
-6. Generate a [Personal Access Token](https://docs.e6data.com/docs/access-control/ip-allowlisting)
-7. Make note of the following, for later use:
-	- e6data username
-    - Personal Access Token
-	- Cluster IP
-​
-### 2.2 Set up a Databricks cluster
-​
-1. Login to your Databricks workspace 
-2. Generate a [personal access token](https://docs.databricks.com/dev-tools/auth.html#personal-access-tokens-for-users)
-3. Spin up a cluster with a configuration equivalent to the engine you’ll be benchmarking against.
-3. Navigate to the `Configuration` tab of the cluster.
-4. Make note of the following, for later use:
-	- Server Hostname
-	- HTTP Path
-​
-## 3. Add the engines to the Benchmark POV Tool
-​
-### 3.1 Login to the Benchmark POV Tool Admin Console
-1. The Admin Console can be accessed here:
-   1. http://localhost:3001/api/ (if locally hosted)
-   2. http://<SERVER_DOMAIN_OR_IP>:3001/api/ (if hosted remotely)
-2. Username: admin (from env parameter DJANGO_SUPERUSER_USERNAME)  
-3. Password: password (from env parameter DJANGO_SUPERUSER_PASSWORD)
-> It is advisable to change the username and password after the first login.
-​
-### 3.2 Create an user account
-1. Navigate to  `Home > User > Users` & click `+ Add`
-2. Create a user by providing a username, email address & password.
-    - These user credentials will be used to login to the frontend.
-3. Click `SAVE`
-​
-### 3.3 Add engines to the Benchmark POV Tool
-1. Navigate to `Benchmarks > Benchmark_ips` & click `+ Add`
-2. Fill in the following details:
-   - Cloud Type: *cloud service provider*
-   - Database name: *database that will be queried, **this should be the same for both engines***
-   - e6data IP: *IP of the e6data cluster* 
-   - e6data User: *username provided in the connector tab* 
-   - e6data Token: *access token generated by the user*
-   - DBR IP: *Hostname of the Databricks cluster* 
-   - DBR HTTP: *HTTP path of the Databricks cluster*
-3. Click `SAVE`
-​
-## 4. Upload queries and run benchmarks
-1. Access the frontend of the Benchmark POV Tool:
-   1. http://localhost:3000/login/ (if locally hosted)
-   2. http://<SERVER_DOMAIN_OR_IP>:3000/login/ (if hosted remotely)
-2. Login using the user credentials created in step 3.2
-3. Click `Create Benchmark` 
-4. Fill in the following details:
-   1. Name your benchmark: *provide a name for this benchmark*
-   2. e6data vs: *select the engine you want to compare e6data against*
-   3. e6data cluster cost (/hr): *the hourly cost of the e6data cluster*
-   4. vs cluster cost (/hr): *the hourly cost of the cluster to benchmark against*
-   5. Run concurrently: *run the queries sequentially or concurrently*
-      1. Concurrent queries: *number of queries to run in parallel*
-      2. Ramp up time: *interval between running batches of concurrent queries (in seconds)*
-5. Click `Next`
-6. Upload a CSV containing a list of queries.
-   1. Download the sample CSV to understand the required structure.
-7. Click `Configure`
-8. Wait for all the queries to complete running.
-9.  The time taken to run each query & the cost incurred will be displayed.
-   1.  A detailed report can be downloaded for further analysis.
-​
-## 5. Uninstall the Benchmark POV Tool
-​
-### 5.1 Remove the Benchmark POV Tool but retain settings & benchmarks for future use
-​
-**Run the docker-compose destroy command**
-> This commands needs to be run from the same directory as the docker-compose.yaml file.
-​
-```console
-docker-compose down
+
+Stop containers while preserving the named MySQL volume:
+
+```bash
+docker compose down
 ```
-​
-### 5.2 Remove the Benchmark POV Tool and delete all associated settings & data.
-​
-**Run the docker-compose destroy command & delete data**
-> This commands needs to be run from the same directory as the docker-compose.yaml file
-​
-```console
-docker-compose down -v
+
+Delete containers **and the persisted benchmark/configuration data**:
+
+```bash
+docker compose down -v
 ```
+
+The `-v` operation is destructive. Export anything you need before running it.
+
+## Known constraints
+
+- The Compose file pins `linux/amd64`; ARM hosts may use emulation and run more slowly.
+- Ports `3000`, `3001`, and `3306` are published on the host. Restrict them with host firewall or network controls when not running solely on localhost.
+- This is a lab tool backed by prebuilt images. Image internals, application upgrades, and security patches are outside this repository.

--- a/python_benchmarks/README.md
+++ b/python_benchmarks/README.md
@@ -1,64 +1,97 @@
-## Here are the python scripts for benchmarking data analytics engines you are using with e6data within minutes
+# Python Benchmark Runners
 
-### Please follow the format of <em>sample.csv</em> file and populate your own queries before starting benchmark scripts.
+These scripts run the same CSV workload against e6data, Trino, or Amazon Athena. They support sequential execution and batched concurrent execution, log a run summary, and write a timestamped result CSV beside the script.
 
-## 1. Dependencies
-### Make sure to install below dependencies and wheel before install e6data-python-connector.
-Amazon Linux / CentOS dependencies
+## Requirements
+
+- Python 3
+- Network access and credentials for the selected engine
+- A C/C++ compiler and Python development headers if installation of the e6data connector requires a local build
+- AWS credentials discoverable by the AWS SDK when running Athena
+
+From this directory, create an isolated environment and install the pinned connector plus the remaining dependencies:
+
 ```bash
-yum install python3-devel gcc-c++ -y
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip wheel
+python -m pip install -r requirements.txt
 ```
-Ubuntu/Debian dependencies
+
+On Debian/Ubuntu, build prerequisites can be installed with `apt install python3-dev g++`; on Amazon Linux/CentOS, use `yum install python3-devel gcc-c++`.
+
+## Query CSV
+
+Use the exact headers `QUERY_ALIAS` and `QUERY`. The database is supplied by the run-level `DB_NAME` variable for every row.
+
+```csv
+QUERY_ALIAS,QUERY
+q1,"SELECT COUNT(*) FROM store_sales"
+q2,"SELECT COUNT(*) FROM catalog_sales"
+```
+
+See [sample.csv](sample.csv). `QUERY_CSV_COLUMN_NAME` can select a differently named query-text column, but the alias column remains `QUERY_ALIAS`.
+
+## Common configuration
+
+Shell assignments must not contain spaces around `=`.
+
 ```bash
-apt install python3-dev g++ -y
+export DB_NAME=tpcds_1000
+export INPUT_CSV_PATH="$PWD/sample.csv"
+export QUERYING_MODE=SEQUENTIAL
+export SHUFFLE_QUERY=false
 ```
-Pip dependencies
+
+| Variable | Required | Default | Meaning |
+|---|---:|---|---|
+| `DB_NAME` | yes | — | Default database/schema for the workload |
+| `INPUT_CSV_PATH` | yes | — | Path to the query CSV |
+| `QUERYING_MODE` | no | `SEQUENTIAL` | Use exactly `CONCURRENT` for batched concurrency |
+| `CONCURRENT_QUERY_COUNT` | concurrent only | `5` | Processes in each submitted batch |
+| `CONCURRENCY_INTERVAL` | concurrent only | `5` | Seconds between batch submissions |
+| `SHUFFLE_QUERY` | no | `false` | Shuffle only when the value is exactly `true` |
+
+Concurrent mode submits the CSV in batches; it is not a fixed-duration load generator. Use the JMeter framework for sustained concurrency or a target arrival rate.
+
+## Run against e6data
+
 ```bash
-pip install wheel
+export ENGINE_IP=cluster.example.com
+export E6_USER=user@example.com
+export E6_TOKEN='<personal-access-token>'
+export CATALOG_NAME=my_catalog
+python e6_benchmark.py
 ```
 
-### 2. Install the python dependent libraries.
-```
-pip install --no-cache-dir -r requirements.txt
-```
-### 3. Set the environment variables.
+The connector uses port 80. The report includes query ID, planner parsing/queue/execution time, and output row count when exposed by `explain_analyse`.
+
+## Run against Trino
+
 ```bash
-export ENGINE_IP=127.0.0.1 # Replace the value with your engine host IP
-export DB_NAME=tpcds_1000 # Replace with your preferred Database
-export INPUT_CSV_PATH=/Users/dummyuser/folder/query_file.csv # Replace the value with your local file path
-export QUERYING_MODE=SEQUENTIAL # for concurrency runs, change the value to CONCURRENT
-export E6_USER=<USER_EMAIL> #Replace the value with your email
-export E6_TOKEN=<USER_ACCESS_TOKEN> # Replace the value with your access token
-export CATALOG_NAME=<CATALOG_NAME> # Replace the value with attached catalog.
-export SHUFFLE_QUERY="true" #If Query Running needs to be shuffled before execution.Default Value is False
-
-
-# In the case of concurrent benchmarking, ensure below variables are set to your requirements
-# The number of queries to be fired at t1 second
-export CONCURRENT_QUERY_COUNT = 20 # Default Value is 5
-
-# The interval between subsequent set of concurrent queries to be fired 
-export CONCURRENCY_INTERVAL = 10 # Default Value is 5
-
-# Example: If your benchmarking needs 50 queries to fire every 2 seconds,
-# export CONCURRENT_QUERY_COUNT = 50
-# export CONCURRENCY_INTERVAL = 2
-
-#Additional environment variables in Athena Benchmarking
-export RESULT_BUCKET=testbucketname # Query results of Athena will be stored in this bucket
-export GLUE_REGION=us-east-1 # Region of AWS Glue. Default Value is us-east-1
+export ENGINE_IP=trino.example.com
+export ENGINE_PORT=8889
+export TRINO_USER=test
+export TRINO_CATALOG=test
+python trino_benchmark.py
 ```
 
-### 4. Run the python script.
-For <em>e6data</em>:
+`ENGINE_PORT`, `TRINO_USER`, and `TRINO_CATALOG` use the defaults shown above when omitted.
+
+## Run against Amazon Athena
+
 ```bash
-python3 e6_benchmark.py
+export RESULT_BUCKET=my-athena-results-bucket
+export GLUE_REGION=us-east-1
+python athena_benchmark.py
 ```
-For <em>Trino</em>:
-```bash
-python3 trino_benchmark.py
-```
-For <em>Athena</em>:
-```bash
-python3 athena_benchmark.py
-```
+
+`RESULT_BUCKET` must be a bucket name, not an `s3://` URL. Results are staged under `s3://<bucket>/Athena/<timestamp>`. Standard AWS credential resolution is used.
+
+## Output and exit behavior
+
+- e6data: `e6data_results_<timestamp>.csv`
+- Trino: `trino_results_<timestamp>.csv`
+- Athena: `athena_results_<timestamp>.csv`
+
+The scripts raise an error after writing the report if any query failed, which makes them suitable for CI smoke checks. Result files may contain query text and error details; review them before sharing or committing.


### PR DESCRIPTION
## Summary

Turns the JMeter directory into a reusable query-engine benchmarking framework for external users. A single config file can run every supported JDBC load model by changing only the test plan and its controlling parameters.

Supported workload models:

- run every query once at fixed concurrency
- sustained fixed concurrency
- constant QPS or QPM arrival rate
- variable arrival-rate profile from a 3-column CSV
- variable concurrent-load profile from a 5-column CSV
- JDBC and HTTP plan families

## Load-profile correctness

Both profile-driven thread groups now receive their schedules before JMeter starts:

- FreeFormArrivalsThreadGroup uses StartValue,EndValue,Duration
- UltimateThreadGroup uses Threads,StartTime,StartupTime,HoldTime,ShutdownTime

The runners inject the selected CSV into a per-run generated JMX artifact. Strict shared parsing rejects malformed profiles. Reports verify delivered arrivals or observed query-in-flight concurrency against the requested profile.

## Runner and reporting improvements

- propagate JMeter, sample-error, and concurrency-sweep failures correctly
- retain diagnostics after a nonzero JMeter exit
- distinguish raw, query, and ignored framework-control samples
- compute short-lived query concurrency using interval overlap
- report successful-sample percentiles, throughput, queue build-up, and drain time
- preserve original and generated plan names
- use collision-safe run IDs
- maintain the S3 engine/cluster/benchmark/run_type/run_id hierarchy
- standardize S3_REPORT_PATH with backwards compatibility for S3_BASE_PATH
- capture query/profile checksums, requested load, Java/JMeter versions, and Git commit
- document the bundled driver checksum and fat-JAR dependency warnings

## External quick start

The root and JMeter READMEs now provide copy-paste setup instructions. test_configs/sample_benchmark.env is one reusable configuration: users set CONNECTION_FILE and QUERY_FILE once, then override TEST_PLAN plus one or two parameters for concurrency, QPS/QPM, or either profile format. No JMX editing or per-load-level config file is required.

## Validation

- 12 unit/integration tests
- Python compilation
- shell syntax validation
- XML validation for every JMX plan
- injection tests for both profile formats
- five-plan bounded live smoke harness
- GitHub Actions workflow for pull requests

Live JDBC validation against an e6data test cluster covered all eight JDBC-capable plans. The arrival profile delivered 64 of approximately 65 samples, and the variable-concurrency profile matched 94.7 percent of measured seconds with zero query errors in both profile-driven runs. A separate five-plan smoke suite passed 5 of 5 plans.

## Safety

Results and credentials remain local/ignored by default, S3 upload is disabled by default, and the documentation recommends starting with low rates in non-production environments.